### PR TITLE
#65 Sundials 2.x vs 3.0 compatibility via CVDense occurences fixed.

### DIFF
--- a/myokit/__init__.py
+++ b/myokit/__init__.py
@@ -157,6 +157,8 @@ FORCE_PYSIDE = False
 SUNDIALS_LIB = []
 # Location of the Sundials (CVODE) header files (.h)
 SUNDIALS_INC = []
+# Sundials major version number. Defaults to 26000.
+SUNDIALS_VERSION = 26000
 # Location of the OpenCL shared library objects (.dll or .so)
 OPENCL_LIB = []
 # Location of the OpenCL header files (.h)

--- a/myokit/_config.py
+++ b/myokit/_config.py
@@ -100,7 +100,7 @@ def _create(path):
             '/usr/local/include',
             '/opt/local/include',
         ]))
-    config.set('sundials','version',myokit.SUNDIALS_VERSION)
+    config.set('sundials', 'version', myokit.SUNDIALS_VERSION)
     # Locations of OpenCL libraries
     config.add_section('opencl')
     config.set(
@@ -212,7 +212,7 @@ def _load():
         for x in config.get('sundials', 'inc').split(';'):
             myokit.SUNDIALS_INC.append(x.strip())
     if config.has_option('sundials', 'version'):
-        myokit.SUNDIALS_VERSION = int(config.get('sundials','version'))
+        myokit.SUNDIALS_VERSION = int(config.get('sundials', 'version'))
     # OpenCL libraries and header files
     if config.has_option('opencl', 'lib'):
         for x in config.get('opencl', 'lib').split(';'):

--- a/myokit/_config.py
+++ b/myokit/_config.py
@@ -100,6 +100,7 @@ def _create(path):
             '/usr/local/include',
             '/opt/local/include',
         ]))
+    config.set('sundials','version',myokit.SUNDIALS_VERSION)
     # Locations of OpenCL libraries
     config.add_section('opencl')
     config.set(
@@ -210,6 +211,8 @@ def _load():
     if config.has_option('sundials', 'inc'):
         for x in config.get('sundials', 'inc').split(';'):
             myokit.SUNDIALS_INC.append(x.strip())
+    if config.has_option('sundials', 'version'):
+        myokit.SUNDIALS_VERSION = int(config.get('sundials','version'))
     # OpenCL libraries and header files
     if config.has_option('opencl', 'lib'):
         for x in config.get('opencl', 'lib').split(';'):

--- a/myokit/_sim/cvode.c
+++ b/myokit/_sim/cvode.c
@@ -79,11 +79,19 @@ equations = model.solvable_order()
 #include <string.h>
 #include <cvode/cvode.h>
 #include <nvector/nvector_serial.h>
-#include <cvode/cvode_dense.h>
+#define MYOKIT_SUNDIALS_VERSION <?= myokit.SUNDIALS_VERSION ?>
+#if MYOKIT_SUNDIALS_VERSION >= 30000
+  #include <sunmatrix/sunmatrix_dense.h>
+  #include <sundials/sundials_linearsolver.h>
+#else
+  #include <cvode/cvode_dense.h>
+#endif
 #include <sundials/sundials_types.h>
 #include "pacing.h"
 
 #define N_STATE <?= model.count_states() ?>
+
+
 
 // Pacing
 ESys epacing;               // Event-based pacing system
@@ -475,6 +483,11 @@ sim_init(PyObject *self, PyObject *args)
     PyObject *key;
     PyObject* ret;
     PyObject *value;
+    #if MYOKIT_SUNDIALS_VERSION >= 30000
+      SUNMatrix sundials_dense_matrix;
+      SUNLinearSolver sundials_linear_solver;
+      ESys_Flag flag;
+    #endif
 
     #ifndef SUNDIALS_DOUBLE_PRECISION
     PyErr_SetString(PyExc_Exception, "Sundials must be compiled with double precision.");
@@ -743,8 +756,23 @@ for var in model.variables(deep=True, state=False, bound=False, const=False):
     if (check_cvode_flag((void*)cvode_mem, "CVodeCreate", 0)) return sim_clean();
     flag_cvode = CVodeInit(cvode_mem, rhs, engine_time, y);
     if (check_cvode_flag(&flag_cvode, "CVodeInit", 1)) return sim_clean();
+    #if MYOKIT_SUNDIALS_VERSION >= 30000
+
+    sundials_dense_matrix = SUNDenseMatrix(N_STATE,N_STATE);
+    if(check_cvode_flag((void *)sundials_dense_matrix, "SUNDenseMatrix", 0)) return sim_clean();
+    /* Create dense SUNLinearSolver object for use by CVode */
+    sundials_linear_solver = SUNDenseLinearSolver(y, sundials_dense_matrix);
+    if(check_cvode_flag((void *)sundials_linear_solver, "SUNDenseLinearSolver", 0)) return sim_clean();
+    /* Call CVDlsSetLinearSolver to attach the matrix and linear solver to CVode */
+    flag = CVDlsSetLinearSolver(cvode_mem, sundials_linear_solver, sundials_dense_matrix);
+    if(check_cvode_flag(&flag, "CVDlsSetLinearSolver", 1)) return sim_clean();
+
+    #else
+
     flag_cvode = CVDense(cvode_mem, N_STATE);
     if (check_cvode_flag(&flag_cvode, "CVDense", 1)) return sim_clean();
+
+    #endif
 
     // Set tolerances
     flag_cvode = CVodeSStolerances(cvode_mem, RCONST(rel_tol), RCONST(abs_tol));

--- a/myokit/formats/ansic/sim.c
+++ b/myokit/formats/ansic/sim.c
@@ -77,7 +77,14 @@ plot 'V.txt' using 1:2 with lines ls 1 title 'Vm'
 #include <math.h>
 #include <cvode/cvode.h>
 #include <nvector/nvector_serial.h>
-#include <cvode/cvode_dense.h>
+#define MYOKIT_SUNDIALS_VERSION <?= myokit.SUNDIALS_VERSION ?>
+#if MYOKIT_SUNDIALS_VERSION >= 30000
+  #include <sunmatrix/sunmatrix_dense.h>
+  #include <sundials/sundials_linearsolver.h>
+#else
+  #include <cvode/cvode_dense.h>
+#endif
+
 #include <sundials/sundials_types.h>
 
 #define N_STATE <?= model.count_states() ?>
@@ -216,6 +223,11 @@ int main()
     N_Vector dy = NULL;
     void *cvode_mem = NULL;
 
+    #if MYOKIT_SUNDIALS_VERSION >= 30000
+      SUNMatrix sundials_dense_matrix;
+      SUNLinearSolver sundials_linear_solver;
+    #endif
+
     /* Create state vector */
     y = N_VNew_Serial(N_STATE);
     if (check_flag((void*)y, "N_VNew_Serial", 0)) goto error;
@@ -306,8 +318,24 @@ while next:
     if (check_flag((void*)cvode_mem, "CVodeCreate", 0)) goto error;
     flag = CVodeInit(cvode_mem, rhs, t, y);
     if (check_flag(&flag, "CVodeInit", 1)) goto error;
+
+    #if MYOKIT_SUNDIALS_VERSION >= 30000
+
+    sundials_dense_matrix = SUNDenseMatrix(N_STATE,N_STATE);
+    if(check_flag((void *)sundials_dense_matrix, "SUNDenseMatrix", 0)) goto error;
+    /* Create dense SUNLinearSolver object for use by CVode */
+    sundials_linear_solver = SUNDenseLinearSolver(y, sundials_dense_matrix);
+    if(check_flag((void *)sundials_linear_solver, "SUNDenseLinearSolver", 0)) goto error;
+    /* Call CVDlsSetLinearSolver to attach the matrix and linear solver to CVode */
+    flag = CVDlsSetLinearSolver(cvode_mem, sundials_linear_solver, sundials_dense_matrix);
+    if(check_flag(&flag, "CVDlsSetLinearSolver", 1)) goto error;
+
+    #else
+
     flag = CVDense(cvode_mem, N_STATE);
     if (check_flag(&flag, "CVDense", 1)) goto error;
+
+    #endif
 
     /* Set tolerances */
     double reltol = RCONST(1.0e-4);


### PR DESCRIPTION
Compatibility with Sundials 2.x and 3.0 probably achieved.
1. Added field to myokit.ini in section [sundials]
Per analogiam to Chaste I have used extended numeric values:
version = 30000
version = 26000
Version number has  to be set manually.
Default value is 26000
2. Tracked down error related to usage of CVDense, for version>=3.x new syntax is used.
Both versions do build and for each Simulation object is properly created.
3. Thorough tests not perfomed; could not get python all in test directory to work (?)
