### PR TITLE
Test Myokit on Python 2.7.6 (shipped with Ubuntu LTS 14.04)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,7 @@ exclude=
     ./dev,
     ./.git,
     ./myokit.egg-info,
+    ./myokit/_exec_old.py,
     ./myokit/formats/python/template,
 ignore=
     # Block comment should start with '# '

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,13 @@ matrix:
           env:
             - MYOKIT_UNIT=true
         - os: linux
+          python: "2.7.6"
+          env:
+            - MYOKIT_UNIT=true
+        - os: linux
           python: "2.7.10"
           env:
             - MYOKIT_UNIT=true
-            - MYOKIT_OLD_MATPLOTLIB=true
         - os: linux
           python: "3.4"
           env:
@@ -71,7 +74,7 @@ before_install:
 
 # Install Myokit and extra testing dependencies
 install:
-  - if [[ $MYOKIT_OLD_MATPLOTLIB == true ]]; then pip install "matplotlib<3"; fi;
+  - pip install --upgrade pip;
   - pip install -e .[dev,optional];
   - if [[ $MYOKIT_COVER == true ]]; then pip install coverage codecov; fi;
   - if [[ $MYOKIT_STYLE == true ]]; then pip install flake8; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ dist: trusty
 
 language: python
 
+# Python version choices:
+#
+# 2.7.0 --> Released 2010-07-03, not tested!
+# 2.7.6 --> Released 2013-11-10, earliest version testable on Travis
+#       --> Version shipped with Ubuntu LTS 14.04 (supported until 2019)
+# 2.7   --> Latest 2.7 version. At the moment 2.7.14 on travis (2018-10-31)
+# 3.0-3.3 --> Bad initial versions of Python 3; Not supported
+# 3.4-3.6 --> Works
+
 matrix:
     # Always put true env variable first, for nicer overview on travis website
     include:
@@ -19,10 +28,6 @@ matrix:
             - MYOKIT_UNIT=true
         - os: linux
           python: "2.7.6"
-          env:
-            - MYOKIT_UNIT=true
-        - os: linux
-          python: "2.7.10"
           env:
             - MYOKIT_UNIT=true
         - os: linux

--- a/myokit/__init__.py
+++ b/myokit/__init__.py
@@ -60,10 +60,9 @@ elif sys.hexversion >= 0x03000000 and sys.hexversion < 0x03040000:
 
 # Exec() that works with Python 2 versions before 2.7.9
 if sys.hexversion < 0x020709F0:
-    from ._old_exec import execf
+    from ._exec_old import _exec    # noqa
 else:
-    def execf(script, globals=None, locals=None):
-        exec(script, globals, locals)
+    from ._exec_new import _exec    # noqa
 del(sys)
 
 

--- a/myokit/__init__.py
+++ b/myokit/__init__.py
@@ -57,6 +57,13 @@ elif sys.hexversion >= 0x03000000 and sys.hexversion < 0x03040000:
     print('Python 3.0 to 3.3 are not supported.')
     print()
     sys.exit(1)
+
+# Exec() that works with Python 2 versions before 2.7.9
+if sys.hexversion < 0x020709F0:
+    from ._old_exec import execf
+else:
+    def execf(script, globals=None, locals=None):
+        exec(script, globals, locals)
 del(sys)
 
 

--- a/myokit/_aux.py
+++ b/myokit/_aux.py
@@ -1020,7 +1020,7 @@ def run(model, protocol, script, stdout=None, stderr=None, progress=None):
                     'get_model': get_model,
                     'get_protocol': get_protocol,
                 }
-                myokit.execf(self.script, environment)
+                myokit._exec(self.script, environment)
             finally:
                 if oldstdout is not None:
                     sys.stdout = oldstdout

--- a/myokit/_aux.py
+++ b/myokit/_aux.py
@@ -1020,7 +1020,7 @@ def run(model, protocol, script, stdout=None, stderr=None, progress=None):
                     'get_model': get_model,
                     'get_protocol': get_protocol,
                 }
-                exec(self.script, environment)
+                myokit.execf(self.script, environment)
             finally:
                 if oldstdout is not None:
                     sys.stdout = oldstdout

--- a/myokit/_exec_new.py
+++ b/myokit/_exec_new.py
@@ -1,0 +1,17 @@
+#
+# Exec function that works with Python versions 2.7.9 and higher
+#
+# This file is part of Myokit
+#  Copyright 2011-2018 Maastricht University, University of Oxford
+#  Licensed under the GNU General Public License v3.0
+#  See: http://myokit.org
+#
+
+
+def _exec(script, globals=None, locals=None):
+    """
+    Wrapper around the built-in function ``exec`` on Python versions 2.7.9 and
+    higher 2.7.9, or a function calling the ``exec`` statement on earlier
+    versions.
+    """
+    exec(script, globals, locals)

--- a/myokit/_exec_old.py
+++ b/myokit/_exec_old.py
@@ -6,5 +6,12 @@
 #  Licensed under the GNU General Public License v3.0
 #  See: http://myokit.org
 #
-def execf(script, globals=None, locals=None):
+
+
+def _exec(script, globals=None, locals=None):
+    """
+    Wrapper around the built-in function ``exec`` on Python versions 2.7.9 and
+    higher 2.7.9, or a function calling the ``exec`` statement on earlier
+    versions.
+    """
     exec script in globals, locals

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -413,9 +413,9 @@ class Expression(object):
         # Create function
         local = {}
         if use_numpy:
-            exec(c, {'numpy': numpy}, local)
+            myokit.execf(c, {'numpy': numpy}, local)
         else:
-            exec(c, {'math': math}, local)
+            myokit.execf(c, {'math': math}, local)
 
         # Return
         return local['ex_pyfunc_generated']

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -413,9 +413,9 @@ class Expression(object):
         # Create function
         local = {}
         if use_numpy:
-            myokit.execf(c, {'numpy': numpy}, local)
+            myokit._exec(c, {'numpy': numpy}, local)
         else:
-            myokit.execf(c, {'math': math}, local)
+            myokit._exec(c, {'math': math}, local)
 
         # Return
         return local['ex_pyfunc_generated']

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -3660,9 +3660,9 @@ class Variable(VarOwner):
         # Create function
         local = {}
         if use_numpy:
-            exec(func, {'numpy': numpy}, local)
+            myokit.execf(func, {'numpy': numpy}, local)
         else:
-            exec(func, {'math': math}, local)
+            myokit.execf(func, {'math': math}, local)
         handle = local['var_pyfunc_generated']
 
         # Return

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -3660,9 +3660,9 @@ class Variable(VarOwner):
         # Create function
         local = {}
         if use_numpy:
-            myokit.execf(func, {'numpy': numpy}, local)
+            myokit._exec(func, {'numpy': numpy}, local)
         else:
-            myokit.execf(func, {'math': math}, local)
+            myokit._exec(func, {'math': math}, local)
         handle = local['var_pyfunc_generated']
 
         # Return

--- a/myokit/_old_exec.py
+++ b/myokit/_old_exec.py
@@ -6,5 +6,5 @@
 #  Licensed under the GNU General Public License v3.0
 #  See: http://myokit.org
 #
-def execf(script, globals=None, locals=None)
+def execf(script, globals=None, locals=None):
     exec script in globals, locals

--- a/myokit/_old_exec.py
+++ b/myokit/_old_exec.py
@@ -1,0 +1,10 @@
+#
+# Exec function that works with Python versions before 2.7.9 (0x020709F0)
+#
+# This file is part of Myokit
+#  Copyright 2011-2018 Maastricht University, University of Oxford
+#  Licensed under the GNU General Public License v3.0
+#  See: http://myokit.org
+#
+def execf(script, globals=None, locals=None)
+    exec script in globals, locals

--- a/myokit/formats/axon/_abf.py
+++ b/myokit/formats/axon/_abf.py
@@ -666,6 +666,8 @@ class AbfFile(object):
             """
             Read and unpack a file section using the given format ``form``.
             """
+            # Form must be a str (so bytes on Python 2)
+            form = str(form)
             if offset is not None:
                 f.seek(offset)
             return struct.unpack(form, f.read(struct.calcsize(form)))

--- a/myokit/formats/wcp/_wcp.py
+++ b/myokit/formats/wcp/_wcp.py
@@ -160,17 +160,20 @@ class WcpFile(object):
             rtype = f.read(4)
 
             # Group number (float set by the user)
-            group_number = struct.unpack('<f', f.read(4))[0]
+            # Note: First argument to struct.unpack must be a str (so bytes on
+            # Python 2).
+            group_number = struct.unpack(str('<f'), f.read(4))[0]
 
             # Time of recording, as float, not sure how to interpret
-            rtime = struct.unpack('<f', f.read(4))[0]
+            rtime = struct.unpack(str('<f'), f.read(4))[0]
 
             # Sampling interval: pretty sure this should be the same as the
             # file wide one in header[b'dt']
-            rint = struct.unpack('<f', f.read(4))[0]
+            rint = struct.unpack(str('<f'), f.read(4))[0]
 
             # Maximum positive limit of A/D converter voltage range
-            vmax = struct.unpack('<' + 'f' * self._nc, f.read(4 * self._nc))
+            vmax = struct.unpack(
+                str('<' + 'f' * self._nc), f.read(4 * self._nc))
 
             # String marker set by user
             marker = f.read(16)

--- a/myokit/lib/markov.py
+++ b/myokit/lib/markov.py
@@ -417,7 +417,7 @@ class LinearModel(object):
         globl = {'numpy': np, 'n': n}
         local = {}
 
-        myokit.execf(code, globl, local)
+        myokit._exec(code, globl, local)
         self._matrix_function = local['matrix_function']
 
         #
@@ -436,7 +436,7 @@ class LinearModel(object):
         code = head + '\n' + '\n'.join(['    ' + line for line in body])
         globl = {'numpy': np}
         local = {}
-        myokit.execf(code, globl, local)
+        myokit._exec(code, globl, local)
         self._rate_list_function = local['rate_list_function']
 
     def current(self):

--- a/myokit/lib/markov.py
+++ b/myokit/lib/markov.py
@@ -417,7 +417,7 @@ class LinearModel(object):
         globl = {'numpy': np, 'n': n}
         local = {}
 
-        exec(code, globl, local)
+        myokit.execf(code, globl, local)
         self._matrix_function = local['matrix_function']
 
         #
@@ -436,7 +436,7 @@ class LinearModel(object):
         code = head + '\n' + '\n'.join(['    ' + line for line in body])
         globl = {'numpy': np}
         local = {}
-        exec(code, globl, local)
+        myokit.execf(code, globl, local)
         self._rate_list_function = local['rate_list_function']
 
     def current(self):

--- a/myokit/pype.py
+++ b/myokit/pype.py
@@ -14,6 +14,7 @@ import re
 import sys
 import parser
 import traceback
+import myokit
 
 try:
     # Python 2
@@ -85,7 +86,7 @@ class TemplateEngine(object):
                 syserr = sys.stderr
                 sys.stdout = stdout
                 sys.stderr = stderr
-                exec(script, variables)
+                myokit.execf(script, variables)
             except Exception:
                 error = sys.exc_info()
             finally:

--- a/myokit/pype.py
+++ b/myokit/pype.py
@@ -86,7 +86,7 @@ class TemplateEngine(object):
                 syserr = sys.stderr
                 sys.stdout = stdout
                 sys.stderr = stderr
-                myokit.execf(script, variables)
+                myokit._exec(script, variables)
             except Exception:
                 error = sys.exc_info()
             finally:

--- a/tests/test_datablock.py
+++ b/tests/test_datablock.py
@@ -1014,7 +1014,7 @@ class DataBlock2dTest(unittest.TestCase):
         x = [[0.8, -0.6, 0], [0.6, 0.8, 0], [1, 2, 2]]
         b.set2d('x', [x])
         self.assertAlmostEqual(
-            b.dominant_eigenvalues('x')[0], 2+0j)
+            b.dominant_eigenvalues('x')[0], 2 + 0j)
 
     def test_eigenvalues(self):
         """

--- a/tests/test_datablock.py
+++ b/tests/test_datablock.py
@@ -1006,11 +1006,15 @@ class DataBlock2dTest(unittest.TestCase):
         self.assertEqual(b.dominant_eigenvalues('x')[0], 11)
 
         # Complex values
+        # Note: This example has complex eigenvalues, but they're not the
+        # dominant ones. If they were, they'd have the same magnitude so the
+        # dominant one would be undefined (and so implementation dependent,
+        # which causes issues for this test. See #230).
         b = myokit.DataBlock2d(3, 3, [1])
-        x = [[0, 1, 0], [0, 0, 1], [1, 0, 0]]
+        x = [[0.8, -0.6, 0], [0.6, 0.8, 0], [1, 2, 2]]
         b.set2d('x', [x])
         self.assertAlmostEqual(
-            b.dominant_eigenvalues('x')[0], -0.5 - np.sqrt(3) / 2j)
+            b.dominant_eigenvalues('x')[0], 2+0j)
 
     def test_eigenvalues(self):
         """


### PR DESCRIPTION
See #230 

This Python version was released in November 2013, which is hopefully far enough back in time to work on most servers, macbooks, etc.

2.7.6 is also the oldest version testable on Travis.