### PR TITLE
Fix for sundials versions like 1.2.3-dev

### DIFF
--- a/myokit/_sim/sundials.py
+++ b/myokit/_sim/sundials.py
@@ -106,6 +106,9 @@ class Sundials(myokit.CModule):
         # Get version from sundials header
         version = Sundials.version()
         if version is not None:
+            # Version can be x.y.z-dev
+            if '-' in version:  # pragma: no cover
+                version = version[:version.index('-')]
             version = [int(x) for x in version.split('.')]
             version = version[0] * 10000 + version[1] * 100 + version[2]
         return version


### PR DESCRIPTION
Stops it from breaking when converting `'3-dev'` to int