### PR TITLE
Cellml state variable ordering

### DIFF
--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -614,6 +614,9 @@ class VarOwner(ModelPart, VarProvider):
     def __getitem__(self, key):
         return self._variables[key]
 
+    def __iter__(self):
+        return iter(self._variables.values())
+
     def __len__(self):
         return len(self._variables)
 
@@ -1612,6 +1615,9 @@ class Model(ObjectWithMeta, VarProvider):
                 t = None
 
         return t
+
+    def __iter__(self):
+        return iter(self._components.values())
 
     def label(self, label):
         """

--- a/myokit/formats/cellml/_importer.py
+++ b/myokit/formats/cellml/_importer.py
@@ -516,6 +516,14 @@ class CellMLImporter(myokit.formats.Importer):
             self.logger().log(
                 'Found ' + str(n) + ' equations in ' + cname + '.')
 
+        # Re-order states by order of appearance
+        ordered = []
+        for c in model.components():
+            for v in c:
+                if v.is_state():
+                    ordered.append(v)
+        model.reorder_state(ordered)
+
         # Use remaining initial values (can be used to set constants)
         for cname, vls in values.items():
             vrs = variables[cname]

--- a/myokit/tests/test_component.py
+++ b/myokit/tests/test_component.py
@@ -229,6 +229,18 @@ class VarOwnerTest(unittest.TestCase):
         self.assertIs(m.binding('time'), None)
         self.assertIs(m.label('membrane_potential'), None)
 
+    def test_sequence_interface(self):
+        # Test the sequence interface implementation
+
+        model = myokit.load_model('example')
+        c = model['membrane']
+
+        vs = [v for v in c]
+        self.assertEqual(vs, list(c.variables()))
+        self.assertEqual(len(vs), len(c))
+        v = c['V']
+        self.assertEqual(v.name(), 'V')
+
     def test_varowner_get(self):
         # Test VarOwner.get().
 

--- a/myokit/tests/test_model.py
+++ b/myokit/tests/test_model.py
@@ -971,6 +971,16 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(m.count_components(), 4)
         m.get('remaining_2')
 
+    def test_sequence_interface(self):
+        # Test the sequence interface implementation
+        model = myokit.load_model('example')
+
+        cs = [c for c in model]
+        self.assertEqual(cs, list(model.components()))
+        self.assertEqual(len(cs), len(model))
+        c = model['membrane']
+        self.assertEqual(c.name(), 'membrane')
+
     def test_show_evaluation_of(self):
         # Test :meth:`Model.show_evaluation_of(variable)`.
         # Depends mostly on `references()`, and `code()` methods.


### PR DESCRIPTION
 Cellml states were in order of appearance of the equations, now are in order of appearance of the variables.

