### PR TITLE
Three fixes

### DIFF
--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -3546,11 +3546,25 @@ class Variable(VarOwner):
         for var in self.refs_by(self._is_state):
             var.set_rhs(var.rhs().clone(subst={old_ref: new_ref}))
 
-        # For the time variable, update all state RHS's as well
+        # For states, also update references to their derivatives
+        if self._is_state:
+            old_ref = myokit.Derivative(myokit.Name(self))
+            new_ref = myokit.Divide(old_ref, fw)
+            for var in self.refs_by(False):
+                var.set_rhs(var.rhs().clone(subst={old_ref: new_ref}))
+
+        # For the time variable, update all state RHS's, and any references to
+        # derivatives
         model = self.parent(Model)
         if self == model.time():
             for var in model.states():
                 var.set_rhs(myokit.Divide(var.rhs(), fw))
+                old_ref = myokit.Derivative(myokit.Name(var))
+                new_ref = myokit.Multiply(old_ref, fw)
+                for ref in var.refs_by(False):
+                    ref.set_rhs(ref.rhs().clone(subst={old_ref: new_ref}))
+
+
 
     def _delete(self, recursive=False, whole_component=False):
         """

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -3564,8 +3564,6 @@ class Variable(VarOwner):
                 for ref in var.refs_by(False):
                     ref.set_rhs(ref.rhs().clone(subst={old_ref: new_ref}))
 
-
-
     def _delete(self, recursive=False, whole_component=False):
         """
         Tells this variable that it's going to be deleted.

--- a/myokit/formats/cellml/v1/_parser.py
+++ b/myokit/formats/cellml/v1/_parser.py
@@ -1019,9 +1019,16 @@ class CellMLParser(object):
         self._check_allowed_content(
             element, ['unit'], ['name', 'base_units'], name)
 
+        # Check the units definition has children
+        children = element.findall(self._join('unit'))
+        if not children:
+            raise CellMLParsingError(
+                'Units element with base_units="no" must contain at least one'
+                ' child unit element.')
+
         # Parse content
         myokit_unit = myokit.units.dimensionless
-        for child in element.findall(self._join('unit')):
+        for child in children:
             myokit_unit *= self._parse_unit(child, owner)
 
         # Add units to owner

--- a/myokit/gui/__init__.py
+++ b/myokit/gui/__init__.py
@@ -70,12 +70,18 @@ if pyqt5:
 
     # Configure Matplotlib for use with PyQt5
     import matplotlib
-    matplotlib.use('Qt5Agg')
     try:
-        matplotlib.rcParams['backend.qt5'] = 'PyQt5'
-    except KeyError:    # pragma: no cover
-        # This is no longer allowed / necessary in matplotlib 3.1.0
+        matplotlib.use('Qt5Agg')
+    except ImportError:
+        # In matplotlib 3.7.0 this raises ImportErrors if a previous backend
+        # was already set.
         pass
+    else:   # pragma: no cover
+        try:
+            matplotlib.rcParams['backend.qt5'] = 'PyQt5'
+        except KeyError:
+            # This is no longer allowed / necessary in matplotlib 3.1.0
+            pass
     import matplotlib.backends.backend_qt5agg as matplotlib_backend
 
     # Set backend variables
@@ -91,12 +97,18 @@ elif pyside2:
 
     # Configure Matplotlib for use with PySide2
     import matplotlib
-    matplotlib.use('Qt5Agg')
     try:
-        matplotlib.rcParams['backend.qt5'] = 'PySide2'
-    except KeyError:    # pragma: no cover
-        # This is no longer allowed / necessary in matplotlib 3.1.0
+        matplotlib.use('Qt5Agg')
+    except ImportError:
+        # In matplotlib 3.7.0 this raises ImportErrors if a previous backend
+        # was already set.
         pass
+    else:   # pragma: no cover
+        try:
+            matplotlib.rcParams['backend.qt5'] = 'PySide2'
+        except KeyError:
+            # This is no longer allowed / necessary in matplotlib 3.1.0
+            pass
     import matplotlib.backends.backend_qt5agg as matplotlib_backend  # noqa
 
     # Set backend variables
@@ -181,12 +193,18 @@ elif pyqt4:
 
     # Configure Matplotlib for use with PyQt4
     import matplotlib
-    matplotlib.use('Qt4Agg')
     try:
-        matplotlib.rcParams['backend.qt4'] = 'PyQt4'
-    except KeyError:    # pragma: no cover
-        # This is no longer allowed / necessary in matplotlib 3.1.0
+        matplotlib.use('Qt4Agg')
+    except ImportError:
+        # In matplotlib 3.7.0 this raises ImportErrors if a previous backend
+        # was already set.
         pass
+    else:   # pragma: no cover
+        try:
+            matplotlib.rcParams['backend.qt4'] = 'PyQt4'
+        except KeyError:
+            # This is no longer allowed / necessary in matplotlib 3.1.0
+            pass
     import matplotlib.backends.backend_qt4agg as matplotlib_backend
 
     # Set backend variables
@@ -265,12 +283,18 @@ elif pyside:
 
     # Configure Matplotlib for use with PySide
     import matplotlib
-    matplotlib.use('Qt4Agg')
     try:
-        matplotlib.rcParams['backend.qt4'] = 'PySide'
-    except KeyError:    # pragma: no cover
-        # This is no longer allowed / necessary in matplotlib 3.1.0
+        matplotlib.use('Qt4Agg')
+    except ImportError:
+        # In matplotlib 3.7.0 this raises ImportErrors if a previous backend
+        # was already set.
         pass
+    else:   # pragma: no cover
+        try:
+            matplotlib.rcParams['backend.qt4'] = 'PySide'
+        except KeyError:
+            # This is no longer allowed / necessary in matplotlib 3.1.0
+            pass
     import matplotlib.backends.backend_qt4agg as matplotlib_backend  # noqa
 
     # Set backend variables

--- a/myokit/tests/test_cellml_v1_parser.py
+++ b/myokit/tests/test_cellml_v1_parser.py
@@ -1008,6 +1008,10 @@ class TestCellMLParser(unittest.TestCase):
         x = '<units name="wooster"><unit units="volt" /></units>'
         self.assertBad(x + x, 'Duplicate units definition')
 
+        # No child unit elements
+        x = '<units name="woopster" />'
+        self.assertBad(x, 'at least one child unit element')
+
         # Missing units definitions
         x = ('<units name="wooster"><unit units="fluther" /></units>')
         self.assertBad(x, 'Unable to resolve network of units')

--- a/myokit/tests/test_variable.py
+++ b/myokit/tests/test_variable.py
@@ -38,6 +38,8 @@ class VariableTest(unittest.TestCase):
             [membrane]
             dot(V) = - (ikr.i + ina.i * 1 [cm^2/uF])
                 in [mV]
+            dotv = 5 [mV/ms] + dot(V)
+                in [mV/ms]
 
             [cell]
             Cm = 0.123 [uF]


### PR DESCRIPTION
Three fixes:
- Fixed bug in Model.convert_units; now also converting references to derivatives
- Stopped allowing empty <units> elements in CellML 1.0 and 1.1
- Updated GUI code to not crash if gui back-end was already set