### PR TITLE
CellML v1 API now complains about duplicate imports

### DIFF
--- a/myokit/formats/cellml/v1/_api.py
+++ b/myokit/formats/cellml/v1/_api.py
@@ -566,19 +566,29 @@ class Model(AnnotatableElement):
         # Check interfaces and connect variables
         # Note: We're allowing the same connection to be specified twice here
         if interface_1 == 'out' and interface_2 == 'in':
-            if variable_2._source not in (None, variable_1):
+            if variable_2._source is None:
+                variable_2._source = variable_1
+            elif variable_2._source is variable_1:
+                raise CellMLError(
+                    'Invalid connection: ' + str(variable_2) + ' is already'
+                    ' connected to ' + str(variable_1) + '.')
+            else:
                 raise CellMLError(
                     'Invalid connection: ' + str(variable_2) + ' has a '
                     + string_1 + '_interface of "in" and is already connected'
                     ' to a variable with an interface of "out".')
-            variable_2._source = variable_1
         elif interface_1 == 'in' and interface_2 == 'out':
-            if variable_1._source not in (None, variable_2):
+            if variable_1._source is None:
+                variable_1._source = variable_2
+            elif variable_1._source is variable_2:
+                raise CellMLError(
+                    'Invalid connection: ' + str(variable_1) + ' is already'
+                    ' connected to ' + str(variable_2) + '.')
+            else:
                 raise CellMLError(
                     'Invalid connection: ' + str(variable_1) + ' has a '
                     + string_2 + '_interface of "in" and is already connected'
                     ' to a variable with an interface of "out".')
-            variable_1._source = variable_2
         else:
             raise CellMLError(
                 'Invalid connection: ' + str(variable_1) + ' has a ' + string_1

--- a/myokit/tests/test_cellml_v1_api.py
+++ b/myokit/tests/test_cellml_v1_api.py
@@ -413,8 +413,8 @@ class TestCellMLModel(unittest.TestCase):
         y = b.add_variable('y', 'volt', 'out', 'none')
         z = c.add_variable('z', 'volt', 'in', 'none')
         m.add_connection(x, z)
-        m.add_connection(x, z)
-        m.add_connection(x, z)
+        self.assertRaisesRegex(
+            cellml.CellMLError, 'Invalid connection', m.add_connection, x, z)
         self.assertRaisesRegex(
             cellml.CellMLError, 'Invalid connection', m.add_connection, y, z)
         self.assertRaisesRegex(

--- a/myokit/tests/test_cellml_v1_parser.py
+++ b/myokit/tests/test_cellml_v1_parser.py
@@ -260,9 +260,11 @@ class TestCellMLParser(unittest.TestCase):
         y = '<map_variables variable_1="x" variable_2="z" />'
         self.assertBad(x + y + z, 'variable_2 attribute must refer to')
 
-        # Connecting twice is fine
+        # Connecting twice is not OK
         y = '<map_variables variable_1="x" variable_2="y" />'
-        self.parse(x + y + y + z)
+        self.assertRaisesRegex(
+            v1.CellMLParsingError, 'already connected to',
+            self.parse, x + y + y + z)
 
         # Bad interfaces etc. propagate from cellml API
         q = ('<component name="a">'


### PR DESCRIPTION
It's a bit unclear from the spec if it's supposed to, but it seems the more sensible choice