### PR TITLE
Cumulative current plot

### DIFF
--- a/myokit/lib/plots.py
+++ b/myokit/lib/plots.py
@@ -265,7 +265,7 @@ def current_arrows(log, voltage, currents, axes=None):
 
 def cumulative_current(
         log, currents, axes=None, labels=None, colors=None, integrate=False,
-        normalise=False):
+        normalise=False, max_currents=None):
     """
     Plots a number of currents, one on top of the other, with the positive and
     negative parts of the current plotted separately.
@@ -294,6 +294,9 @@ def cumulative_current(
     ``normalise``
         Set this to ``True`` to normalise the graph at every point, so that the
         relative contribution of each current is shown.
+    ``max_currents``
+        Set this to any integer n to display only the first n currents, and
+        group the rest together in a remainder current.
 
     The best results are obtained if relatively constant currents are specified
     early. Another rule of thumb is to specify the currents roughly in the
@@ -327,34 +330,54 @@ def cumulative_current(
         pos /= np.sum(pos, axis=0)
         neg /= -np.sum(neg, axis=0)
 
+    # Number of currents to show
+    if max_currents is None:
+        show_remainder = False
+        nc = len(currents)
+    else:
+        show_remainder = True
+        max_currents = int(max_currents)
+        nc = 1 + max_currents
+
     # Colors
-    n = len(currents)
     if colors:
-        while len(colors) < n:
+        while len(colors) < nc:
             colors.extend(colors)
     else:
         # Colormap
         cmap = matplotlib.cm.get_cmap(name='tab20')
-        colors = [cmap(i) for i in range(len(currents))]
+        colors = [cmap(i) for i in range(nc)]
 
     # Plot
     op = on = 0
-    for k, c in enumerate(currents):
+    for k in range(nc):
+        if k == max_currents:
+            # Color and label for remainder
+            color = '#cccccc'
+            label = 'Remainder'
 
-        # Get color
-        color = colors[k]
+            # Positive and negative remainder parts
+            p = op + np.sum(pos[k:], axis=0)
+            n = on + np.sum(neg[k:], axis=0)
 
-        # Get label
-        if labels:
-            label = labels[k]
         else:
-            if integrate:
-                label = 'Q(' + c[c.find('.') + 1:] + ')'
+            # Get color
+            color = colors[k]
+
+            # Get label
+            if labels:
+                label = labels[k]
             else:
-                label = c[c.find('.') + 1:]
+                c = currents[k]
+                if integrate:
+                    label = 'Q(' + c[c.find('.') + 1:] + ')'
+                else:
+                    label = c[c.find('.') + 1:]
+
+            # Get positive and negative parts
+            p, n = op + pos[k], on + neg[k]
 
         # Plot!
-        p, n = op + pos[k], on + neg[k]
         axes.fill_between(t, p, op, facecolor=color)
         axes.fill_between(t, n, on, facecolor=color)
         axes.plot(t, p, color=color, label=label)

--- a/myokit/tests/test_lib_plots.py
+++ b/myokit/tests/test_lib_plots.py
@@ -25,9 +25,8 @@ class LibPlotTest(unittest.TestCase):
     """
 
     def test_simulation_times(self):
-        """
-        Test the simulation times() plots (has several modes).
-        """
+        # Test the simulation times() plots (has several modes).
+
         # Select matplotlib backend that doesn't require a screen
         import matplotlib
         matplotlib.use('template')
@@ -86,9 +85,8 @@ class LibPlotTest(unittest.TestCase):
             ValueError, plots.simulation_times, st, rt, ev, mode='xxx')
 
     def test_current_arrows(self):
-        """
-        Test the current arrows plot.
-        """
+        # Test the current arrows plot.
+
         # Select matplotlib backend that doesn't require a screen
         import matplotlib
         matplotlib.use('template')
@@ -119,9 +117,8 @@ class LibPlotTest(unittest.TestCase):
         plt.show()
 
     def test_cumulative_current(self):
-        """
-        Test the cumulative current plot.
-        """
+        # Test the cumulative current plot.
+
         # Select matplotlib backend that doesn't require a screen
         import matplotlib
         matplotlib.use('template')
@@ -169,6 +166,12 @@ class LibPlotTest(unittest.TestCase):
         # Normalise currents
         plt.figure()
         plots.cumulative_current(d, currents, normalise=True)
+        plt.legend()
+        plt.show()
+
+        # Normalise currents and set maximum number of currents shown
+        plt.figure()
+        plots.cumulative_current(d, currents, normalise=True, max_currents=3)
         plt.legend()
         plt.show()
 


### PR DESCRIPTION
now has an option to bundle all remaining currents into one, which is useful when plotting the relative contribution of each current to the net current.