### PR TITLE
All compiled modules now use a pid-based hash in there name. 

### DIFF
--- a/myokit/_sim/cable.py
+++ b/myokit/_sim/cable.py
@@ -182,6 +182,7 @@ class Simulation1d(myokit.CModule):
         # Unique simulation id
         Simulation1d._index += 1
         module_name = 'myokit_sim1d_' + str(Simulation1d._index)
+        module_name += '_' + str(myokit._pid_hash())
 
         # Arguments
         args = {

--- a/myokit/_sim/compiler.py
+++ b/myokit/_sim/compiler.py
@@ -44,6 +44,7 @@ class Compiler(myokit.CModule):
 
         # Create back-end
         mname = 'myokit_compiler_info_' + str(Compiler._index)
+        mname += '_' + str(myokit._pid_hash())
         fname = os.path.join(myokit.DIR_CFUNC, SOURCE_FILE)
         args = {'module_name': mname}
         try:

--- a/myokit/_sim/fiber_tissue.py
+++ b/myokit/_sim/fiber_tissue.py
@@ -341,6 +341,7 @@ class FiberTissueSimulation(myokit.CModule):
         # Unique simulation id
         FiberTissueSimulation._index += 1
         mname = 'myokit_sim_fiber_tissue_' + str(FiberTissueSimulation._index)
+        mname += '_' + str(myokit._pid_hash())
 
         # Arguments
         args = {

--- a/myokit/_sim/icsim.py
+++ b/myokit/_sim/icsim.py
@@ -110,6 +110,7 @@ class ICSimulation(myokit.CppModule):
         # Unique simulation id
         ICSimulation._index += 1
         module_name = 'myokit_ICSimulation_' + str(ICSimulation._index)
+        module_name += '_' + str(myokit._pid_hash())
 
         # Arguments
         args = {

--- a/myokit/_sim/jacobian.py
+++ b/myokit/_sim/jacobian.py
@@ -59,6 +59,7 @@ class JacobianTracer(myokit.CppModule):
         # Extension module id
         JacobianTracer._index += 1
         module_name = 'myokit_JacobianTracer_' + str(JacobianTracer._index)
+        module_name += '_' + str(myokit._pid_hash())
 
         # Template arguments
         args = {
@@ -235,8 +236,9 @@ class JacobianCalculator(myokit.CppModule):
 
         # Extension module id
         JacobianCalculator._index += 1
-        module_name = 'myokit_JacobianCalculator_' \
-            + str(JacobianCalculator._index)
+        module_name = 'myokit_JacobianCalculator_'
+        module_name += str(JacobianCalculator._index)
+        module_name += '_' + str(myokit._pid_hash())
 
         # Template arguments
         args = {

--- a/myokit/_sim/opencl.py
+++ b/myokit/_sim/opencl.py
@@ -45,6 +45,7 @@ class OpenCL(myokit.CModule):
         # Create back-end and cache it
         OpenCL._index += 1
         mname = 'myokit_opencl_info_' + str(OpenCL._index)
+        mname += '_' + str(myokit._pid_hash())
         fname = os.path.join(myokit.DIR_CFUNC, SOURCE_FILE)
         args = {'module_name': mname}
 

--- a/myokit/_sim/openclsim.py
+++ b/myokit/_sim/openclsim.py
@@ -277,6 +277,7 @@ class SimulationOpenCL(myokit.CModule):
         # Create back-end
         SimulationOpenCL._index += 1
         mname = 'myokit_sim_opencl_' + str(SimulationOpenCL._index)
+        mname += '_' + str(myokit._pid_hash())
         fname = os.path.join(myokit.DIR_CFUNC, SOURCE_FILE)
         args = {
             'module_name': mname,

--- a/myokit/_sim/psim.py
+++ b/myokit/_sim/psim.py
@@ -157,6 +157,7 @@ class PSimulation(myokit.CppModule):
         # Unique simulation id
         PSimulation._index += 1
         module_name = 'myokit_PSimulation_' + str(PSimulation._index)
+        module_name += '_' + str(myokit._pid_hash())
 
         # Arguments
         args = {

--- a/myokit/_sim/rhs.py
+++ b/myokit/_sim/rhs.py
@@ -56,6 +56,7 @@ class RhsBenchmarker(myokit.CModule):
         # Extension module id
         RhsBenchmarker._index += 1
         module_name = 'myokit_RhsBenchmarker_' + str(RhsBenchmarker._index)
+        module_name += '_' + str(myokit._pid_hash())
 
         # Distutils arguments
         args = {

--- a/myokit/_sim/sundials.py
+++ b/myokit/_sim/sundials.py
@@ -45,6 +45,7 @@ class Sundials(myokit.CModule):
 
         # Create Sundials back-end
         mname = 'myokit_sundials_info_' + str(Sundials._index)
+        mname += '_' + str(myokit._pid_hash())
         fname = os.path.join(myokit.DIR_CFUNC, SOURCE_FILE)
         args = {'module_name': mname}
         try:


### PR DESCRIPTION
Closes #253.