### PR TITLE
Unit system: Lax equality comparison and floating point exponents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ matrix:
     include:
         # Unit tests on OS/X, running first because this one's slow
         - os: osx
-          language: generic
+          osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
+          language: shell
           env:
             - MYOKIT_UNIT=true
         # Style checking
@@ -82,7 +83,6 @@ before_install:
   # OS/X
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew update-reset;
-      brew upgrade python2;
       brew install sundials;
     fi;
 

--- a/docs/source/api_formats/cellml_v1.rst
+++ b/docs/source/api_formats/cellml_v1.rst
@@ -35,8 +35,6 @@ CellML Model API
 
 .. autoclass:: UnsupportedBaseUnitsError
 
-.. autoclass:: UnsupportedUnitExponentError
-
 .. autoclass:: UnsupportedUnitOffsetError
 
 .. autofunction:: clean_identifier

--- a/docs/source/api_formats/cellml_v2.rst
+++ b/docs/source/api_formats/cellml_v2.rst
@@ -33,10 +33,6 @@ CellML Model API
 
 .. autoclass:: Units
 
-.. autoclass:: UnitsError
-
-.. autoclass:: UnsupportedUnitExponentError
-
 .. autoclass:: AnnotatableElement
 
 .. autoclass:: CellMLError

--- a/docs/source/api_index/myokit.formats.rst
+++ b/docs/source/api_index/myokit.formats.rst
@@ -66,7 +66,6 @@ myokit.formats.cellml.v1
 - :class:`myokit.formats.cellml.v1.Units`
 - :class:`myokit.formats.cellml.v1.UnitsError`
 - :class:`myokit.formats.cellml.v1.UnsupportedBaseUnitsError`
-- :class:`myokit.formats.cellml.v1.UnsupportedUnitExponentError`
 - :class:`myokit.formats.cellml.v1.UnsupportedUnitOffsetError`
 - :class:`myokit.formats.cellml.v1.Variable`
 - :meth:`myokit.formats.cellml.v1.write_file`
@@ -90,8 +89,6 @@ myokit.formats.cellml.v2
 - :meth:`myokit.formats.cellml.v2.parse_file`
 - :meth:`myokit.formats.cellml.v2.parse_string`
 - :class:`myokit.formats.cellml.v2.Units`
-- :class:`myokit.formats.cellml.v2.UnitsError`
-- :class:`myokit.formats.cellml.v2.UnsupportedUnitExponentError`
 - :class:`myokit.formats.cellml.v2.Variable`
 - :meth:`myokit.formats.cellml.v2.write_file`
 - :meth:`myokit.formats.cellml.v2.write_string`

--- a/myokit/__init__.py
+++ b/myokit/__init__.py
@@ -511,16 +511,20 @@ from ._aux import (  # noqa
     # Benchmarking
     Benchmarker,
 
-    # Misc
+    # Floating point
+    _close,
+    _cround,
     _feq,
     _fgeq,
+    _fround,
     format_float_dict,
+    strfloat,
+
+    # Misc
     format_path,
     _lvsd,
     _pid_hash,
     _rmtree,
-    _round_if_int,
-    strfloat,
 
     # Snapshot creation for replicability
     pack_snapshot,

--- a/myokit/_aux.py
+++ b/myokit/_aux.py
@@ -1468,14 +1468,14 @@ def _feq(a, b):
     each other that the difference could be a single rounding error.
     """
     # Note the initial == check handles infinity
-    return a == b or abs(a - b) <= max(abs(a), abs(b)) * sys.float_info.epsilon
+    return a == b or abs(a - b) < max(abs(a), abs(b)) * sys.float_info.epsilon
 
 
 def _fgeq(a, b):
     """
     Checks if ``a >= b``, but using :meth:`myokit._feq` instead of ``=``.
     """
-    return a >= b or abs(a - b) <= max(abs(a), abs(b)) * sys.float_info.epsilon
+    return a >= b or abs(a - b) < max(abs(a), abs(b)) * sys.float_info.epsilon
 
 
 def _fround(x):
@@ -1498,7 +1498,7 @@ def _close(a, b, reltol=1e-9, abstol=1e-9):
     point representation.
     """
     # Note the initial == check handles infinity
-    return a == b or abs(a - b) <= max(reltol * max(abs(a), abs(b)), abstol)
+    return a == b or abs(a - b) < max(reltol * max(abs(a), abs(b)), abstol)
 
 
 def _cround(x, reltol=1e-9, abstol=1e-9):

--- a/myokit/_aux.py
+++ b/myokit/_aux.py
@@ -1483,7 +1483,7 @@ def _round_if_int(x):
     so, rounds it to that integer.
     """
     ix = round(x)
-    return ix if _feq(x, ix) else x
+    return int(ix) if _feq(x, ix) else x
 
 
 def _rmtree(path):

--- a/myokit/_aux.py
+++ b/myokit/_aux.py
@@ -1467,23 +1467,47 @@ def _feq(a, b):
     Checks if floating point numbers ``a`` and ``b`` are equal, or so close to
     each other that the difference could be a single rounding error.
     """
-    return a == b or abs(a - b) < max(abs(a), abs(b)) * sys.float_info.epsilon
+    # Note the initial == check handles infinity
+    return a == b or abs(a - b) <= max(abs(a), abs(b)) * sys.float_info.epsilon
 
 
 def _fgeq(a, b):
     """
     Checks if ``a >= b``, but using :meth:`myokit._feq` instead of ``=``.
     """
-    return a >= b or abs(a - b) < max(abs(a), abs(b)) * sys.float_info.epsilon
+    return a >= b or abs(a - b) <= max(abs(a), abs(b)) * sys.float_info.epsilon
 
 
-def _round_if_int(x):
+def _fround(x):
     """
     Checks if a float ``x`` is within 1 rounding error of an integer, and if
-    so, rounds it to that integer.
+    so, converts it to that integer.
     """
-    ix = round(x)
-    return int(ix) if _feq(x, ix) else x
+    ix = int(round(x))
+    return ix if _feq(x, ix) else x
+
+
+def _close(a, b, reltol=1e-9, abstol=1e-9):
+    """
+    Test whether two numbers are close enough to be considered equal.
+
+    Differs from :meth:`myokit._feq` in that it tries to answer the question
+    "are two number resulting from various calculations close enough to be
+    considered equal". Whereas `_feq` aims to deal with numbers that are
+    numerically indistinguishable but still have a slightly different floating
+    point representation.
+    """
+    # Note the initial == check handles infinity
+    return a == b or abs(a - b) <= max(reltol * max(abs(a), abs(b)), abstol)
+
+
+def _cround(x, reltol=1e-9, abstol=1e-9):
+    """
+    Checks if a float ``x`` is close to an integer with :meth:`close()`, and if
+    so, converts it to that integer.
+    """
+    ix = int(round(x))
+    return ix if _close(x, ix, reltol, abstol) else x
 
 
 def _rmtree(path):

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -2514,13 +2514,13 @@ class Unit(object):
         The check for closeness is made with a relative tolerance of ``reltol``
         and absolute tolerance of ``abstol``, using::
 
-            abs(a - b) <= max(reltol * max(abs(a), abs(b)), abstol)
+            abs(a - b) < max(reltol * max(abs(a), abs(b)), abstol)
 
         Unit exponents are stored as floating point numbers and compared
         directly. Unit multipliers are stored as ``log10(multiplier)``, and
-        compared without transforming back. As a result, units such as ``pF``
-        won't be considered close to ``nF``, but units such as ``[F]`` will be
-        considered close to ``[F (1.000000001)]``.
+        compared without transforming back. As a result, units such as
+        ``[nF]^2`` won't be considered close to ``[pF]^2``, but units such as
+        ``[F]`` will be considered close to ``[F] * (1 + 1e-12)``.
         """
         if unit1 is unit2:
             return True
@@ -2547,7 +2547,7 @@ class Unit(object):
         check for closeness if made with a relative tolerance of ``reltol`` and
         absolute tolerance of ``abstol``, using::
 
-            abs(a - b) <= max(reltol * max(abs(a), abs(b)), abstol)
+            abs(a - b) < max(reltol * max(abs(a), abs(b)), abstol)
 
         """
         for i, a in enumerate(unit1._x):

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -2941,7 +2941,7 @@ class Unit(object):
         if m != 0:
             m = rnd(m)
             m = 10**m
-            if m >=1:
+            if m >= 1:
                 m = rnd(m)
             if m < 1e6:
                 m = str(m)

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -2370,16 +2370,20 @@ def _expr_error_message(owner, e):
 
 class Unit(object):
     """
-    Defines a unit.
+    Represents a unit.
 
-    Each unit consists of
+    Most users won't want to create units, but instead use e.g.
+    ``myokit.parse_unit('kg/mV')`` or ``myokit.units.mV``.
 
-      * A list of seven integers: these are the exponents for the basic SI
+    Each Unit consists of
+
+      * A list of seven floats: these are the exponents for the basic SI
         units: ``[g, m, s, A, K, cd, mol]``. Gram is used instead of the SI
         defined kilogram to create a more coherent syntax.
       * A multiplier. This includes both quantifiers (such as milli, kilo, Mega
         etc) and conversion factors (for example 1inch = 2.54cm). Multipliers
-        are specified in powers of 10.
+        are specified in powers of 10, e.g. to create an inch use the
+        multiplier log10(2.54).
 
     There are two ways to create a unit:
 

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -1343,10 +1343,7 @@ class Power(InfixExpression):
         if unit1 is None:
             return None
 
-        try:
-            return unit1 ** self._op2.eval()
-        except TypeError as e:
-            raise EvalUnitError(self, str(e))
+        return unit1 ** self._op2.eval()
 
 
 class Function(Expression):
@@ -1461,10 +1458,7 @@ class Sqrt(Function):
         unit = self._operands[0]._eval_unit(mode)
         if unit is None:
             return None
-        try:
-            return unit ** 0.5
-        except TypeError as e:
-            raise EvalUnitError(self, str(e))
+        return unit ** 0.5
 
 
 class Sin(UnaryDimensionlessFunction):

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -1014,11 +1014,16 @@ class Model(ObjectWithMeta, VarProvider):
                 raise myokit.IntegrityError('No RHS set for ' + var.qname())
             e = e.eval_unit(mode)
 
+            # No unit? Then allow (in strict mode v and e are never None)
+            if v is None or e is None:
+                continue
+
             # Rhs unit from a state? Then multiply by time to get var's unit
-            if t is not None and e is not None and var.is_state():
+            if t is not None and var.is_state():
                 e *= t
 
-            if v != e and v is not None and e is not None:
+            # Compare loosely
+            if not myokit.Unit.close(v, e):
                 msg = 'Incompatible units in <' + var.qname() + '>'
                 if var._token is not None:
                     msg += ' on line ' + str(var._token[2])

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -941,23 +941,26 @@ class Model(ObjectWithMeta, VarProvider):
 
     def check_units(self, mode=myokit.UNIT_TOLERANT):
         """
-        Checks the units used in this model. Models can specify units in two
-        ways:
+        Checks the units used in this model.
 
-        1. By setting a Variable unit. This is done using the ``in`` keyword in
-           ``mmt`` syntax or through the method
-           :meth:`myokit.Variable.set_unit()`. This specifies the unit the
-           variable's value should be in.
-        2. By adding units to the literals in variables' right hand
-           expressions. This is done using square brackets in ``mmt`` syntax
-           (for example ``5 [m] / 10 [s]``) or by adding a unit when creating
-           a Number object, for example ``Number(2, myokit.parse_unit('mV')``.
+        Models can specify units in two ways:
 
-        Per variable, the unit check proceeds in two steps:
+        1. By setting variable units. This is done using the ``in`` keyword in
+           ``mmt`` syntax or through :meth:`myokit.Variable.set_unit()`. This
+           specifies the unit that a variable's value should be in.
+        2. By adding units to literals. This is done using square brackets in
+           ``mmt`` syntax (for example ``5 [m] / 10 [s]``) or by adding a unit
+           when creating a Number object, for example
+           ``myokit.Number(2, myokit.units.mV)``.
 
-        1. The unit resulting from the variable's RHS is evaluated. This may
-           trigger an :class:`myokit.IncompatibleUnitExpression` if any
-           inompatibilities are found in the expression (see below).
+        When checking a model's units, this method loops over all variables and
+        performs two checks:
+
+        1. The unit resulting from the variable's RHS is evaluated. This
+           involves checking rules such as "in ``x + y``, ``x`` and ``y`` must
+           have the same units, or "in ``exp(x)`` the units of ``x`` must be
+           ``dimensionless``". A :class:`myokit.IncompatibleUnitExpression`
+           will be raised if any inompatibilities are found.
         2. The calculated unit is compared with the variable unit. An
            ``IncompatibleUnitError`` will be triggered if the two units don't
            match.
@@ -967,8 +970,8 @@ class Model(ObjectWithMeta, VarProvider):
         In strict mode (``mode=myokit.UNIT_STRICT``), all unspecified units in
         expressions are treated as "dimensionless". For example, the expression
         ``5 * V`` where ``V`` is in ``[mV]`` will be treated as dimensionless
-        times millivolt (or ``[1] * [mV] in mmt syntax), resulting in the unit
-        ``[mV]``.
+        times millivolt (or ``[1] * [mV]`` in mmt syntax), resulting in the
+        unit ``[mV]``.
         The expression ``5 + V`` will be interpreted as dimensionless plus
         millivolt, and will raise an error.
         In strict mode, functions such as ``sin`` and ``exp`` will check that
@@ -996,8 +999,8 @@ class Model(ObjectWithMeta, VarProvider):
         checking ``x = 5 [mV]`` because ``x`` is dimensionless while ``5 [mV]``
         has units ``[mV]``. In tolerant mode, no error will be raised. When
         tolerantly evaluating ``y = 3[A] + x`` it will be assumed that ``x`` is
-        also in ``[A]``, because no variable unit is given that says otherwise,
-        despite the RHS of ``x`` having units ``mV``.
+        also in ``[A]``, because no variable unit is given that says otherwise
+        (despite the RHS of ``x`` having units ``mV``).
         """
         # Get time unit
         t = self.time_unit(mode)

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -1018,7 +1018,9 @@ class Model(ObjectWithMeta, VarProvider):
             e = e.eval_unit(mode)
 
             # No unit? Then allow (in strict mode v and e are never None)
-            if v is None or e is None:
+            if v is None or e is None:  # pragma: no cover
+                # Adding a print() here shows this line is hit, coverage still
+                # disagrees. Puzzled.
                 continue
 
             # Rhs unit from a state? Then multiply by time to get var's unit

--- a/myokit/formats/cellml/v1/__init__.py
+++ b/myokit/formats/cellml/v1/__init__.py
@@ -17,7 +17,6 @@ from ._api import (     # noqa
     Units,
     UnitsError,
     UnsupportedBaseUnitsError,
-    UnsupportedUnitExponentError,
     UnsupportedUnitOffsetError,
     Variable,
     is_valid_identifier,

--- a/myokit/formats/cellml/v1/_api.py
+++ b/myokit/formats/cellml/v1/_api.py
@@ -76,10 +76,10 @@ def create_unit_name(unit):
         name, multiplier = name, ''
 
     # Could also be because it's g*m/mol^2
-    # (Exponents are integers, so don't need to deal with floats here)
     name = name.replace('^', '')
     name = name.replace('/', '_per_')
     name = name.replace('*', '_')
+    name = name.replace('.', '_dot_')
 
     # Remove "1_" from "1_per_mV"
     if name[:2] == '1_':
@@ -189,15 +189,6 @@ class UnsupportedBaseUnitsError(UnitsError):
         self.units = units
         super(UnsupportedBaseUnitsError, self).__init__(
             'Unsupported base units "' + units + '".')
-
-
-class UnsupportedUnitExponentError(UnitsError):
-    """
-    Raised when units with non-integer exponents are used.
-    """
-    def __init__(self):
-        super(UnsupportedUnitExponentError, self).__init__(
-            'Non-integer unit exponents are not supported.')
 
 
 class UnsupportedUnitOffsetError(UnitsError):
@@ -454,7 +445,6 @@ class Model(AnnotatableElement):
     Support notes for 1.0 and 1.1:
 
     - Units with offsets are not supported, including the base units "celsius".
-    - Units with a non-integer exponent are not supported.
     - Defining new base units is not supported.
     - Reactions are not supported.
     - Models that take derivatives with respect to more than one variable are
@@ -1323,11 +1313,9 @@ class Units(object):
             except ValueError:
                 raise CellMLError(
                     'Unit exponent must be a real number (5.4.2.4).')
-            if not myokit._feq(e, int(e)):
-                raise UnsupportedUnitExponentError
 
             # Apply exponent to unit
-            unit **= int(e)
+            unit **= e
 
         # Handle multiplier
         if multiplier is not None:

--- a/myokit/formats/cellml/v2/__init__.py
+++ b/myokit/formats/cellml/v2/__init__.py
@@ -15,8 +15,6 @@ from ._api import (     # noqa
     Component,
     Model,
     Units,
-    UnitsError,
-    UnsupportedUnitExponentError,
     Variable,
     is_basic_real_number_string,
     is_identifier,

--- a/myokit/formats/cellml/v2/_api.py
+++ b/myokit/formats/cellml/v2/_api.py
@@ -102,10 +102,10 @@ def create_unit_name(unit):
         name, multiplier = name, ''
 
     # Could also be because it's g*m/mol^2
-    # (Exponents are integers, so don't need to deal with floats here)
     name = name.replace('^', '')
     name = name.replace('/', '_per_')
     name = name.replace('*', '_')
+    name = name.replace('.', '_dot_')
 
     # Remove "1_" from "1_per_mV"
     if name[:2] == '1_':
@@ -159,21 +159,6 @@ class CellMLError(myokit.MyokitError):
     Raised when an invalid CellML 2.0 model is created or detected, or when a
     model uses CellML features that Myokit does not support.
     """
-
-
-class UnitsError(CellMLError):
-    """
-    Raised when unsupported unit features are used.
-    """
-
-
-class UnsupportedUnitExponentError(UnitsError):
-    """
-    Raised when units with non-integer exponents are used.
-    """
-    def __init__(self):
-        super(UnsupportedUnitExponentError, self).__init__(
-            'Units with non-integer exponents are not supported.')
 
 
 class Component(AnnotatableElement):
@@ -323,7 +308,6 @@ class Model(AnnotatableElement):
     - Imports are not supported.
     - Reset rules are not supported.
     - Using variables in ``initial_value`` attributes is not supported.
-    - Units with a non-integer exponent are not supported.
     - Defining new base units is not supported.
     - All equations must be of the form ``x = ...`` or ``dx/dt = ...``.
     - Models that take derivatives with respect to more than one variable are
@@ -1226,12 +1210,8 @@ class Units(object):
                     + str(multiplier) + '"')
             e = float(exponent)
 
-            # Only integers are supported by Myokit
-            if not myokit._feq(e, int(e)):
-                raise UnsupportedUnitExponentError
-
             # Apply exponent to unit
-            unit **= int(e)
+            unit **= e
 
         # Handle multiplier
         if multiplier is not None:

--- a/myokit/formats/cellml/v2/_parser.py
+++ b/myokit/formats/cellml/v2/_parser.py
@@ -705,15 +705,9 @@ class CellMLParser(object):
                 ' not supported.)')
 
         # Parse content
-        try:
-            myokit_unit = myokit.units.dimensionless
-            for child in children:
-                myokit_unit *= self._parse_unit(child, owner)
-        except myokit.formats.cellml.v2.UnitsError as e:
-            warnings.warn(
-                'Unable to parse definition for units "' + str(name) + '",'
-                ' using `dimensionless` instead. (' + str(e) + ')')
-            myokit_unit = myokit.units.dimensionless
+        myokit_unit = myokit.units.dimensionless
+        for child in children:
+            myokit_unit *= self._parse_unit(child, owner)
 
         # Add units to owner
         try:

--- a/myokit/tests/test_aux.py
+++ b/myokit/tests/test_aux.py
@@ -179,15 +179,38 @@ class AuxTest(unittest.TestCase):
 
         # Test rounding
         self.assertNotEqual(49, y)
-        self.assertEqual(49, myokit._round_if_int(y))
-        self.assertNotEqual(49, myokit._round_if_int(x))
-        self.assertEqual(0.5, myokit._round_if_int(0.5))
+        self.assertEqual(49, myokit._fround(y))
+        self.assertNotEqual(49, myokit._fround(x))
+        self.assertEqual(0.5, myokit._fround(0.5))
+        self.assertIsInstance(myokit._fround(y), int)
 
         # Try with negative numbers
         self.assertNotEqual(-49, -y)
-        self.assertEqual(-49, myokit._round_if_int(-y))
-        self.assertNotEqual(-49, myokit._round_if_int(-x))
-        self.assertEqual(-0.5, myokit._round_if_int(-0.5))
+        self.assertEqual(-49, myokit._fround(-y))
+        self.assertNotEqual(-49, myokit._fround(-x))
+        self.assertEqual(-0.5, myokit._fround(-0.5))
+
+        # Test that _close allows bigger errors
+        x = 49
+        y = x * (1 + 1e-11)
+        self.assertNotEqual(x, y)
+        self.assertFalse(myokit._feq(x, y))
+        self.assertTrue(myokit._close(x, y))
+
+        # And that close thinks everything small is equal
+        x = 1e-16
+        y = 1e-12
+        self.assertNotEqual(x, y)
+        self.assertFalse(myokit._feq(x, y))
+        self.assertTrue(myokit._close(x, y))
+
+        # Test rounding based on closeness
+        x = 49
+        y = x * (1 + 1e-11)
+        self.assertNotEqual(x, y)
+        self.assertEqual(x, myokit._cround(y))
+        self.assertIsInstance(myokit._cround(y), int)
+        self.assertNotEqual(x, myokit._cround(49.001))
 
     def test_format_float_dict(self):
         # Test myokit.format_float_dict.

--- a/myokit/tests/test_cellml_v1_api.py
+++ b/myokit/tests/test_cellml_v1_api.py
@@ -627,11 +627,11 @@ class TestCellML1ModelConversion(unittest.TestCase):
         self.assertEqual(
             cm['c2']['z'].units().myokit_unit(), myokit.units.mole)
 
-        # But evaluated units can have errors
-        y.set_rhs('1 [mV] ^ 1.2')    # Not supported by Myokit's unit system
+        # ...and units can have fractional exponents
+        y.set_rhs('1 [mV] ^ 1.2')
         cm = cellml.Model.from_myokit_model(m)
         self.assertEqual(
-            cm['c2']['y'].units().myokit_unit(), myokit.units.dimensionless)
+            cm['c2']['y'].units().myokit_unit(), myokit.units.mV**1.2)
 
     def test_m2c_nested_variables(self):
         # Test nested variables are handled, and name conflicts are handled
@@ -1325,9 +1325,6 @@ class TestCellML1Units(unittest.TestCase):
         self.assertRaisesRegex(
             cellml.CellMLError, 'must be a real number',
             cellml.Units.parse_unit_row, 'meter', exponent='bert')
-        self.assertRaises(
-            cellml.UnsupportedUnitExponentError,
-            cellml.Units.parse_unit_row, 'meter', exponent=1.23)
 
         # Test multiplier
         u = cellml.Units.parse_unit_row('meter', multiplier=1.234)

--- a/myokit/tests/test_cellml_v1_api.py
+++ b/myokit/tests/test_cellml_v1_api.py
@@ -633,6 +633,13 @@ class TestCellML1ModelConversion(unittest.TestCase):
         self.assertEqual(
             cm['c2']['y'].units().myokit_unit(), myokit.units.mV**1.2)
 
+        # If a variable doesn't have units, the RHS will be inspected. This can
+        # lead to unit errors, which should be ignored
+        y.set_rhs('1 [mV] + 3 [A]')
+        cm = cellml.Model.from_myokit_model(m)
+        self.assertEqual(
+            cm['c2']['y'].units().myokit_unit(), myokit.units.dimensionless)
+
     def test_m2c_nested_variables(self):
         # Test nested variables are handled, and name conflicts are handled
         # when creating a CellML model.

--- a/myokit/tests/test_cellml_v1_parser.py
+++ b/myokit/tests/test_cellml_v1_parser.py
@@ -961,16 +961,15 @@ class TestCellMLParser(unittest.TestCase):
         self.assertEqual(
             myokit.units.dimensionless, m.find_units('nonzero').myokit_unit())
 
-        # Non-integer exponents are not supported: treated as dimensionless
+        # Non-integer exponents are supported
         x = ('<units name="unsup">'
-             '  <unit units="meter" />'
              '  <unit units="ampere" exponent="2.34" />'
              '</units>')
-        with WarningCollector() as w:
-            m = self.parse(x)
-        self.assertIn('Non-integer', w.text())
+        m = self.parse(x)
         self.assertEqual(
-            myokit.units.dimensionless, m.find_units('unsup').myokit_unit())
+            m.find_units('unsup').myokit_unit(),
+            myokit.units.ampere**2.34,
+        )
 
         # Offset must be a number
         x = ('<units name="wooster">'

--- a/myokit/tests/test_cellml_v2_api.py
+++ b/myokit/tests/test_cellml_v2_api.py
@@ -804,11 +804,11 @@ class TestCellML2ModelConversion(unittest.TestCase):
         self.assertEqual(
             cm['c2']['z'].units().myokit_unit(), myokit.units.mole)
 
-        # But evaluated units can have errors
-        y.set_rhs('1 [mV] ^ 1.2')    # Not supported by Myokit's unit system
+        # ...and can have float exponents
+        y.set_rhs('1 [mV] ^ 1.2')
         cm = cellml.Model.from_myokit_model(m)
         self.assertEqual(
-            cm['c2']['y'].units().myokit_unit(), myokit.units.dimensionless)
+            cm['c2']['y'].units().myokit_unit(), myokit.units.mV ** 1.2)
 
     def test_m2c_nested_variables(self):
         # Test nested variables are handled, and name conflicts are handled
@@ -1623,11 +1623,6 @@ class TestCellML2Units(unittest.TestCase):
         self.assertRaisesRegex(
             cellml.CellMLError, 'must be a real number',
             cellml.Units.parse_unit_row, 'metre', exponent='bert')
-
-        # Test unsupported (non-integer) exponent
-        self.assertRaises(
-            cellml.UnsupportedUnitExponentError,
-            cellml.Units.parse_unit_row, 'metre', exponent=1.23)
 
         # Test multiplier
         u = cellml.Units.parse_unit_row('metre', multiplier=1.234)

--- a/myokit/tests/test_cellml_v2_api.py
+++ b/myokit/tests/test_cellml_v2_api.py
@@ -804,11 +804,18 @@ class TestCellML2ModelConversion(unittest.TestCase):
         self.assertEqual(
             cm['c2']['z'].units().myokit_unit(), myokit.units.mole)
 
-        # ...and can have float exponents
+        # ...and can have non-integer exponents
         y.set_rhs('1 [mV] ^ 1.2')
         cm = cellml.Model.from_myokit_model(m)
         self.assertEqual(
             cm['c2']['y'].units().myokit_unit(), myokit.units.mV ** 1.2)
+
+        # If a variable doesn't have units, the RHS will be inspected. This can
+        # lead to unit errors, which should be ignored
+        y.set_rhs('1 [mV] + 3 [A]')
+        cm = cellml.Model.from_myokit_model(m)
+        self.assertEqual(
+            cm['c2']['y'].units().myokit_unit(), myokit.units.dimensionless)
 
     def test_m2c_nested_variables(self):
         # Test nested variables are handled, and name conflicts are handled

--- a/myokit/tests/test_cellml_v2_parser.py
+++ b/myokit/tests/test_cellml_v2_parser.py
@@ -621,16 +621,15 @@ class TestCellMLParser(unittest.TestCase):
              '</units>')
         self.assertBad(x, 'must have a units attribute')
 
-        # Non-integer exponents are not supported: treated as dimensionless
+        # Non-integer exponents are supported
         x = ('<units name="unsup">'
-             '  <unit units="volt" />'
              '  <unit units="ampere" exponent="2.34" />'
              '</units>')
-        with WarningCollector() as w:
-            m = self.parse(x)
-        self.assertIn('non-integer exponent', w.text())
+        m = self.parse(x)
         self.assertEqual(
-            myokit.units.dimensionless, m.find_units('unsup').myokit_unit())
+            m.find_units('unsup').myokit_unit(),
+            myokit.units.ampere**2.34
+        )
 
     def test_units(self):
         # Test parsing a units definition

--- a/myokit/tests/test_expressions.py
+++ b/myokit/tests/test_expressions.py
@@ -149,24 +149,6 @@ class ExpressionTest(unittest.TestCase):
         self.assertEqual(m[2], '  1 + 2 * (3 + 4 * (5 [mV] + 6 [A]))')
         self.assertEqual(m[3], '                    ~~~~~~~~~~~~~~')
 
-        # Special case: invalid power or sqrt
-        x = myokit.parse_expression('1 + 2 * 3 [mV] ^ 1.4')
-        with self.assertRaises(myokit.IncompatibleUnitError) as e:
-            x.eval_unit()
-        m = str(e.exception).splitlines()
-        self.assertEqual(len(m), 4)
-        self.assertEqual(m[2], '  1 + 2 * 3 [mV] ^ 1.4')
-        self.assertEqual(m[3], '          ~~~~~~~~~~~~')
-
-        # Special case: invalid power or sqrt
-        x = myokit.parse_expression('1 + 2 * sqrt(3 [mV])')
-        with self.assertRaises(myokit.IncompatibleUnitError) as e:
-            x.eval_unit()
-        m = str(e.exception).splitlines()
-        self.assertEqual(len(m), 4)
-        self.assertEqual(m[2], '  1 + 2 * sqrt(3 [mV])')
-        self.assertEqual(m[3], '          ~~~~~~~~~~~~')
-
     def test_int_conversion(self):
         # Test conversion of expressions to int.
 
@@ -1534,9 +1516,7 @@ class SqrtTest(unittest.TestCase):
         # Test in tolerant mode
         #self.assertEqual(z.rhs().eval_unit(), None)
         x.set_unit(myokit.units.volt)
-        self.assertRaisesRegex(
-            myokit.IncompatibleUnitError, 'non-integer exponents',
-            z.rhs().eval_unit)
+        self.assertEqual(z.rhs().eval_unit(), myokit.units.volt**0.5)
         x.set_unit(myokit.units.volt ** 2)
         self.assertEqual(z.rhs().eval_unit(), myokit.units.volt)
         x.set_unit(None)
@@ -1546,9 +1526,7 @@ class SqrtTest(unittest.TestCase):
         s = myokit.UNIT_STRICT
         self.assertEqual(z.rhs().eval_unit(s), myokit.units.dimensionless)
         x.set_unit(myokit.units.volt)
-        self.assertRaisesRegex(
-            myokit.IncompatibleUnitError, 'non-integer exponents',
-            z.rhs().eval_unit, s)
+        self.assertEqual(z.rhs().eval_unit(), myokit.units.volt**0.5)
         x.set_unit(myokit.units.volt ** 2)
         self.assertEqual(z.rhs().eval_unit(s), myokit.units.volt)
         x.set_unit(None)

--- a/myokit/tests/test_model.py
+++ b/myokit/tests/test_model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Tests the Model class.
 #
@@ -256,6 +256,21 @@ class ModelTest(unittest.TestCase):
             self.assertIsNotNone(token)
             self.assertEqual(token[2], 3)
             self.assertEqual(token[3], 0)
+
+        # Test comparison with floating point issues
+        m = myokit.parse_model('\n'.join([
+            '[[model]]',
+            '[a]',
+            'x = 1 [cm^3] bind time',
+            '    in [cm^3]',
+            'y = 2 [day]',
+            '    in [day]',
+            'z = 3 [day^3]',
+            '    in [day^3]',
+            'a = (x / y / y / y) * z',
+            '    in [cm^3]',
+        ]))
+        m.check_units(s)
 
     def test_clone(self):
         # Test :meth:`Model.clone()

--- a/myokit/tests/test_unit.py
+++ b/myokit/tests/test_unit.py
@@ -347,6 +347,14 @@ class MyokitUnitTest(unittest.TestCase):
         nn = myokit.units.N * 1e7
         self.assertEqual(str(nn), '[N (1e+07)]')
 
+        # Unit very similar to a known unit
+        c = myokit.units.V
+        d = c * 1.000000001
+        self.assertFalse(c == d)
+        self.assertTrue(myokit.Unit.close(c, d))
+        self.assertEqual(str(c), '[V]')
+        self.assertEqual(str(d), '[V]')
+
     def test_repr(self):
         # Test :meth:`Unit.repr()`.
 


### PR DESCRIPTION
A more lenient equality comparison was required, see #575 

While implementing this, it made sense to also start allowing floating point exponents (e.g. `mV^1.23`).
The only reason this was not implemented was to avoid the hassle of lenient equality checks.

Allowing non-integer exponents removed a restriction for CellML 1 and 2, so updated that as well...