### PR TITLE
Sbml tweaks

### DIFF
--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -736,8 +736,15 @@ class Model(object):
             # Set initial value
             expr = compartment.initial_value()
             if expr is not None:
-                var.set_rhs(expr.clone(
-                    subst=expression_references))
+                try:
+                    var.set_rhs(expr.clone(
+                        subst=expression_references))
+                except AttributeError:
+                    raise SBMLError(
+                        'Initial value for the size of <' + str(compartment) +
+                        '> contains unreferenced parameters/variables. Please'
+                        ' use e.g. the `add_parameter` method to add reference'
+                        ' to parameters in the model.')
 
             if compartment.is_rate():
                 # Get initial state

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -841,7 +841,13 @@ class Model(object):
                 expr = myokit.Multiply(conversion_factor, expr)
 
             # Get myokit amount variable
-            var = species_amount_references[species.sid()]
+            try:
+                var = species_amount_references[species.sid()]
+            except KeyError:
+                raise SBMLError(
+                    'Kinetic law of <' + str(reaction) + '> contains '
+                    'unreferenced species <' + str(species) + '>. Please, '
+                    'use the `add_species` method to reference species.')
 
             if not var.is_state():
                 # Get initial state
@@ -866,7 +872,14 @@ class Model(object):
                 expr = myokit.PrefixMinus(expr)
 
             # Set RHS
-            var.set_rhs(expr.clone(subst=expression_references))
+            try:
+                var.set_rhs(expr.clone(subst=expression_references))
+            except AttributeError:
+                raise SBMLError(
+                    'Reaction rate expression of <' + str(reaction) + '> for <'
+                    + str(species) + '> contains unreferenced parameters/'
+                    'variables. Please use e.g. the `add_parameter` method to '
+                    'add reference to parameters in the model.')
 
     def _set_rhs_products(
             self, reaction, variable_references, species_amount_references,

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -947,6 +947,9 @@ class Model(object):
             if expr is not None:
                 # Need to convert initial value if initial value is provided
                 # in concentration
+                if expr_in_amount is None:
+                    expr_in_amount = species.is_amount()
+
                 if expr_in_amount is False:
                     # Get initial compartment size
                     compartment = species.compartment()

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -946,8 +946,8 @@ class Model(object):
             expr, expr_in_amount = species.initial_value()
             if expr is not None:
                 # Need to convert initial value if initial value is provided
-                # concentration
-                if not expr_in_amount:
+                # in concentration
+                if expr_in_amount is False:
                     # Get initial compartment size
                     compartment = species.compartment()
                     size = variable_references[compartment.sid()]
@@ -1403,20 +1403,21 @@ class Species(Quantity):
 
         self._conversion_factor = factor
 
-    def set_initial_value(self, value, in_amount=False):
+    def set_initial_value(self, value, in_amount=None):
         """
         Sets a :class:`myokit.Expression` for this species' initial value.
 
         `in_amount` is a boolean that indicates whether the initial value is
-        measured in amount (True) or concentration (False).
+        measured in amount (True) or concentration (False). If set to `None`
+        value is treated to have the same units as the species.
         """
         if not isinstance(value, myokit.Expression):
             raise SBMLError(
                 '<' + str(value) + '> needs to be an instance of '
                 'myokit.Expression.')
-        if not isinstance(in_amount, bool):
+        if (in_amount is not None) and (not isinstance(in_amount, bool)):
             raise SBMLError(
-                '<in_amount> needs to be an instance of bool.')
+                '<in_amount> needs to be an instance of bool or None.')
 
         self._initial_value = value
         self._initial_value_in_amount = in_amount

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -631,7 +631,13 @@ class Model(object):
             # Get component from reference list
             compartment = species.compartment()
             compartment_sid = compartment.sid()
-            component = component_references[compartment_sid]
+            try:
+                component = component_references[compartment_sid]
+            except KeyError:
+                raise SBMLError(
+                    'The <' + str(compartment) + '> for <' + str(species) + '>'
+                    ' is not referenced in model. Please use the '
+                    '`add_compartment` method to reference a compartment.')
 
             # Add species in amount to component
             # (needed for reactions, even if species is defined in
@@ -929,7 +935,13 @@ class Model(object):
                 expr = myokit.Multiply(conversion_factor, expr)
 
             # Get myokit amount variable
-            var = species_amount_references[species.sid()]
+            try:
+                var = species_amount_references[species.sid()]
+            except KeyError:
+                raise SBMLError(
+                    'Kinetic law of <' + str(reaction) + '> contains '
+                    'unreferenced species <' + str(species) + '>. Please, '
+                    'use the `add_species` method to reference species.')
 
             if not var.is_state():
                 # Get initial state
@@ -951,7 +963,14 @@ class Model(object):
                 expr = myokit.Plus(var.rhs(), expr)
 
             # Set RHS
-            var.set_rhs(expr.clone(subst=expression_references))
+            try:
+                var.set_rhs(expr.clone(subst=expression_references))
+            except AttributeError:
+                raise SBMLError(
+                    'Reaction rate expression of <' + str(reaction) + '> for <'
+                    + str(species) + '> contains unreferenced parameters/'
+                    'variables. Please use e.g. the `add_parameter` method to '
+                    'add reference to parameters in the model.')
 
     def _set_rhs_species(
             self, species_amount_references, variable_references,

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -694,7 +694,15 @@ class Model(object):
                     species = species_reference.species()
                     compartment = species.compartment()
                     compartment_sid = compartment.sid()
-                    component = component_references[compartment_sid]
+                    try:
+                        component = component_references[compartment_sid]
+                    except KeyError:
+                        raise SBMLError(
+                            'The <' + str(compartment) + '> of <' +
+                            str(species) + '> in <' + str(reaction) + '> is '
+                            'not referenced in the model. Please use the '
+                            '`add_compartment` method to reference the '
+                            'compartment.')
 
                     # Add variable to component
                     var = component.add_variable_allow_renaming(

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -1004,16 +1004,22 @@ class Model(object):
                 if expr_in_amount is None:
                     expr_in_amount = species.is_amount()
 
-                if expr_in_amount is False:
-                    # Get initial compartment size
-                    compartment = species.compartment()
-                    size = variable_references[compartment.sid()]
+                try:
+                    if expr_in_amount is False:
+                        # Get initial compartment size
+                        compartment = species.compartment()
+                        size = variable_references[compartment.sid()]
 
-                    # Convert initial value from concentration to amount
-                    expr = myokit.Multiply(expr, myokit.Name(size))
+                        # Convert initial value from concentration to amount
+                        expr = myokit.Multiply(expr, myokit.Name(size))
 
-                # Set initial value
-                var.set_rhs(expr.clone(subst=expression_references))
+                    # Set initial value
+                    var.set_rhs(expr.clone(subst=expression_references))
+                except AttributeError:
+                    raise SBMLError(
+                        'Initial value of <' + str(species) + '> contains '
+                        'unreferenced parameters/variables. Please use e.g. '
+                        'the `add_parameter` method to reference expressions.')
 
             if species.is_rate():
                 # Get initial state
@@ -1034,16 +1040,22 @@ class Model(object):
             if expr is not None:
                 # Need to convert initial value if species is measured in
                 # concentration (assignments match unit of measurement)
-                if not species.is_amount():
-                    # Get initial compartment size
-                    compartment = species.compartment()
-                    size = variable_references[compartment.sid()]
+                try:
+                    if not species.is_amount():
+                        # Get initial compartment size
+                        compartment = species.compartment()
+                        size = variable_references[compartment.sid()]
 
-                    # Convert initial value from concentration to amount
-                    expr = myokit.Multiply(expr, myokit.Name(size))
+                        # Convert initial value from concentration to amount
+                        expr = myokit.Multiply(expr, myokit.Name(size))
 
-                # Set initial value
-                var.set_rhs(expr.clone(subst=expression_references))
+                    # Set initial value
+                    var.set_rhs(expr.clone(subst=expression_references))
+                except AttributeError:
+                    raise SBMLError(
+                        'Value of <' + str(species) + '> contains '
+                        'unreferenced parameters/variables. Please use e.g. '
+                        'the `add_parameter` method to reference expressions.')
 
     def _set_rhs_parameters(self, variable_references, expression_references):
         """

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -764,8 +764,15 @@ class Model(object):
             # (assignmentRule overwrites initialAssignment)
             expr = compartment.value()
             if expr is not None:
-                var.set_rhs(expr.clone(
-                    subst=expression_references))
+                try:
+                    var.set_rhs(expr.clone(
+                        subst=expression_references))
+                except AttributeError:
+                    raise SBMLError(
+                        'Value for the size of <' + str(compartment) +
+                        '> contains unreferenced parameters/variables. Please'
+                        ' use e.g. the `add_parameter` method to add reference'
+                        ' to parameters in the model.')
 
     def _set_reactions(
             self, variable_references, species_amount_references,

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -738,7 +738,7 @@ class Model(object):
 
             if compartment.is_rate():
                 # Promote size to state variable
-                var.promote(state_value=var.eval())
+                var.promote(state_value=var.eval() if var.rhs() else 0)
 
             # Set RHS
             # (assignmentRule overwrites initialAssignment)
@@ -813,14 +813,10 @@ class Model(object):
 
             if not var.is_state():
                 # Promote amount to state variable
-                try:
-                    var.promote(state_value=var.eval())
-                    var.set_rhs(None)
-                except AttributeError:
-                    var.promote()
-                    var.set_rhs(None)
+                var.promote(state_value=var.eval() if var.rhs() else 0)
+                var.set_rhs(None)
 
-            if var.rhs().eval():
+            if var.eval():
                 # Subtract rate contributions
                 # (Reaction removes species from compartment)
                 expr = myokit.Minus(var.rhs(), expr)
@@ -875,12 +871,8 @@ class Model(object):
 
             if not var.is_state():
                 # Promote amount to state variable
-                try:
-                    var.promote(state_value=var.eval())
-                    var.set_rhs(None)
-                except AttributeError:
-                    var.promote()
-                    var.set_rhs(None)
+                var.promote(state_value=var.eval() if var.rhs() else 0)
+                var.set_rhs(None)
 
             if var.rhs().eval():
                 # Add rate contributions
@@ -923,7 +915,7 @@ class Model(object):
 
             if species.is_rate():
                 # Promote species to state variable
-                var.promote(var.eval())
+                var.promote(state_value=var.eval() if var.rhs() else 0)
 
             # Set RHS (reactions are dealt with elsewhere)
             expr = species.value()
@@ -958,7 +950,7 @@ class Model(object):
 
             if parameter.is_rate():
                 # Promote parameter to state variable
-                var.promote(state_value=var.eval())
+                var.promote(state_value=var.eval() if var.rhs() else 0)
 
             # Set RHS
             # (assignmentRule overwrites initialAssignment)
@@ -996,7 +988,7 @@ class Model(object):
 
                 if species_reference.is_rate():
                     # Promote stoichiometry to state variable
-                    var.promote(state_value=var.eval())
+                    var.promote(state_value=var.eval() if var.rhs() else 0)
 
                 # Set RHS
                 # (assignmentRule overwrites initialAssignment)

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -1069,8 +1069,15 @@ class Model(object):
             # Set initial value
             expr = parameter.initial_value()
             if expr is not None:
-                var.set_rhs(expr.clone(
-                    subst=expression_references))
+                try:
+                    var.set_rhs(expr.clone(
+                        subst=expression_references))
+                except AttributeError:
+                    raise SBMLError(
+                        'Initial value of <' + str(parameter) +
+                        '> contains unreferenced parameters/variables. Please'
+                        ' use e.g. the `add_parameter` method to add reference'
+                        ' to parameters in the model.')
 
             if parameter.is_rate():
                 # Get initial state
@@ -1090,8 +1097,15 @@ class Model(object):
             # (assignmentRule overwrites initialAssignment)
             expr = parameter.value()
             if expr is not None:
-                var.set_rhs(expr.clone(
-                    subst=expression_references))
+                try:
+                    var.set_rhs(expr.clone(
+                        subst=expression_references))
+                except AttributeError:
+                    raise SBMLError(
+                        'Value of <' + str(parameter) + '> contains '
+                        'unreferenced parameters/variables. Please use e.g.'
+                        ' the `add_parameter` method to add reference '
+                        'to parameters in the model.')
 
     def _set_rhs_stoichiometries(
             self, variable_references, expression_references):

--- a/myokit/formats/sbml/_parser.py
+++ b/myokit/formats/sbml/_parser.py
@@ -254,12 +254,6 @@ class SBMLParser(object):
                 lambda x, y: myokit.Name(model.assignable(x)),
             ))
 
-            # Indicate for species that the units of the inital value are
-            # correct (initialAssignments are meant to assign the value
-            # in the correct units amount/concentration)
-            if isinstance(var, myokit.formats.sbml.Species):
-                var.set_correct_initial_value(True)
-
         except myokit.formats.sbml.SBMLError as e:
             raise SBMLParsingError(
                 'Unable to parse initial assignment: ' + str(e), element)

--- a/myokit/formats/sbml/_parser.py
+++ b/myokit/formats/sbml/_parser.py
@@ -633,15 +633,15 @@ class SBMLParser(object):
             # Get initial amount
             value = element.get('initialAmount')
 
-            # Indicate whether units of initial value are correct
-            species.set_correct_initial_value(species.is_amount())
+            # Indicate whether units of initial value are in amount
+            value_in_amount = True
 
             # If initial amount is not provided, get initial concentration
             if value is None:
                 value = element.get('initialConcentration')
 
                 # Indicate whether units of initial value are correct
-                species.set_correct_initial_value(not species.is_amount())
+                value_in_amount = False
 
             # Set initial value
             if value is not None:
@@ -653,7 +653,8 @@ class SBMLParser(object):
                         + str(value) + '".', element)
 
                 # Ignore units in equations
-                species.set_initial_value(myokit.Number(value))
+                species.set_initial_value(
+                    myokit.Number(value), value_in_amount)
 
             # Set conversion factor if provided (must refer to a parameter)
             factor = element.get('conversionFactor')

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -13,7 +13,6 @@ import unittest
 import myokit
 import myokit.formats
 import myokit.formats.sbml as sbml
-from myokit.formats.sbml import SBMLParser
 
 # Unit testing in Python 2 and 3
 try:

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1285,6 +1285,14 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertEqual(pp.rhs(), myokit.Number(7))
         self.assertEqual(pp.unit(), myokit.units.pF)
 
+        # Unreferenced parameter
+        m = sbml.Model()
+        p_bad = sbml.Parameter(m, 'p_bad')
+        p = m.add_parameter('param')
+        p.set_initial_value(myokit.Name(p_bad))
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Initial value of <', m.myokit_model)
+
     def test_parameters_values(self):
         # Tests adding parameters set with a value (non-state)
 
@@ -1305,6 +1313,14 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertFalse(pp.is_state())
         self.assertEqual(pp.rhs().code(), '7 + 3')
         self.assertEqual(pp.unit(), myokit.units.pF)
+
+        # Unreferenced parameter
+        m = sbml.Model()
+        p_bad = sbml.Parameter(m, 'p_bad')
+        p = m.add_parameter('param')
+        p.set_value(myokit.Name(p_bad))
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Value of <', m.myokit_model)
 
     def test_parameter_values_rate(self):
         # Tests adding parameters set with a value (state)
@@ -1334,6 +1350,14 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertTrue(pp.is_state())
         self.assertEqual(pp.rhs(), myokit.Number(3.2))
         self.assertEqual(pp.unit(), myokit.units.pF)
+
+        # Unreferenced parameter
+        m = sbml.Model()
+        p_bad = sbml.Parameter(m, 'p_bad')
+        p = m.add_parameter('param')
+        p.set_value(myokit.Name(p_bad), is_rate=True)
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Value of <', m.myokit_model)
 
     def test_species(self):
         # Tests whether species initialisation in amount and concentration

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1556,6 +1556,25 @@ class SBMLTestMyokitModel(unittest.TestCase):
         var = mm.get('c.s2_amount')
         self.assertEqual(var.eval(), 2 / 1.2 + 1.5)
 
+    def test_reaction_bad_compartment(self):
+        # Tests handling of unreferenced compartment for reactants/products.
+
+        # Bad compartment for reactant
+        m = sbml.Model()
+        c = sbml.Compartment(m, 'compartment')
+        s1 = sbml.Species(c, 's1', False, False, False)
+        r = m.add_reaction('r')
+        r.add_reactant(s1, 'sr1')
+        self.assertRaisesRegex(sbml.SBMLError, 'The <', m.myokit_model)
+
+        # Bad compartment for product
+        m = sbml.Model()
+        c = sbml.Compartment(m, 'compartment')
+        s1 = sbml.Species(c, 's1', False, False, False)
+        r = m.add_reaction('r')
+        r.add_product(s1, 'sr1')
+        self.assertRaisesRegex(sbml.SBMLError, 'The <', m.myokit_model)
+
     def test_reaction_bad_species(self):
         # Tests handling of unreferenced species in kinetic law.
 

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1928,27 +1928,6 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertEqual(var.state_value(), 0)
         self.assertEqual(var.eval(), 3.82)
 
-    def test_reaction_stoichiometry_unreferenced_parameter(self):
-        # Tests whether stoichiometry is handled in reactions,
-        # when it's set by a unreferenced parameter.
-        pass
-        # TODO:
-        # m = sbml.Model()
-        # p = sbml.Parameter(m, 'parameter')
-        # c = m.add_compartment('c')
-        # c.set_initial_value(myokit.Number(1.2))
-        # s1 = m.add_species(c, 's1')
-        # s1.set_initial_value(myokit.Number(2), in_amount=True)
-        # s2 = m.add_species(c, 's2')
-        # s2.set_initial_value(myokit.Number(1.5))
-        # r = m.add_reaction('r')
-        # sr1 = r.add_reactant(s1, 'sr1')
-        # sr1.set_value(myokit.Name(p))
-        # sr2 = r.add_product(s2, 'sr2')
-        # sr2.set_value(value=myokit.Number(3.82), is_rate=True)
-        # r.set_kinetic_law(myokit.Plus(myokit.Name(s1), myokit.Name(s2)))
-        # mm = m.myokit_model()
-
     def test_reaction_stoichiometries_exist(self):
         # Tests whether stoichiometries are created properly.
 
@@ -1992,6 +1971,18 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertEqual(stoich_reactant.eval(), 2.1)
         self.assertEqual(stoich_product.eval(), 3.5)
 
+        # Bad initial value
+        m = sbml.Model()
+        p = sbml.Parameter(m, 'parameter')
+        c = m.add_compartment('c')
+        s1 = m.add_species(c, 's1')
+        r = m.add_reaction('r')
+        sr1 = r.add_reactant(s1, 'sr1')
+        sr1.set_initial_value(myokit.Name(p))
+        r.set_kinetic_law(myokit.Name(s1))
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Initial value of <', m.myokit_model)
+
     def test_reaction_stoichiometry_values(self):
         # Tests whether values of parameters are set correctly.
 
@@ -2027,6 +2018,18 @@ class SBMLTestMyokitModel(unittest.TestCase):
         var = mm.get('c.sr2')
         self.assertEqual(var.state_value(), 3.5)
         self.assertEqual(var.eval(), 9.23)
+
+        # Bad value
+        m = sbml.Model()
+        p = sbml.Parameter(m, 'parameter')
+        c = m.add_compartment('c')
+        s1 = m.add_species(c, 's1')
+        r = m.add_reaction('r')
+        sr1 = r.add_reactant(s1, 'sr1')
+        sr1.set_value(myokit.Name(p))
+        r.set_kinetic_law(myokit.Name(s1))
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Value of <', m.myokit_model)
 
     def test_reaction_stoichiometries(self):
         # Tests whether stoichiometries are added properly to the associated

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1372,8 +1372,8 @@ class SBMLTestMyokitModel(unittest.TestCase):
         s2.set_initial_value(myokit.Number(4))
         mm = m.myokit_model()
         sc = mm.get('comp.spec_2_concentration')
-        self.assertFalse(ms.is_state())
-        self.assertEqual(ms.rhs(), myokit.Number(4))
+        self.assertFalse(sc.is_state())
+        self.assertEqual(sc.rhs(), myokit.Number(4))
         sa = mm.get('comp.spec_2_amount')
         self.assertFalse(sa.is_state())
         self.assertEqual(sa.rhs().code(), '4 * comp.size')
@@ -1396,13 +1396,13 @@ class SBMLTestMyokitModel(unittest.TestCase):
         s2.set_value(myokit.Number(4))
         mm = m.myokit_model()
         sc = mm.get('comp.spec_2_concentration')
-        self.assertFalse(ms.is_state())
-        self.assertEqual(ms.rhs(), myokit.Number(4))
+        self.assertFalse(sc.is_state())
+        self.assertEqual(sc.rhs(), myokit.Number(4))
         sa = mm.get('comp.spec_2_amount')
         self.assertFalse(sa.is_state())
         self.assertEqual(sa.rhs().code(), '4 * comp.size')
 
-    def test_species_value_rate (self):
+    def test_species_value_rate(self):
         # Tests converting setting species defined through an ODE equation
 
         # Species in amount
@@ -1427,9 +1427,9 @@ class SBMLTestMyokitModel(unittest.TestCase):
         s2.set_value(myokit.Number(4), is_rate=True)
         mm = m.myokit_model()
         sc = mm.get('comp.spec_2_concentration')
-        self.assertTruee(ms.is_state())
-        self.assertEqual(ms.rhs(), myokit.Number(4))
-        self.assertEqual(ms.state_value(), 0)
+        self.assertTrue(sc.is_state())
+        self.assertEqual(sc.rhs(), myokit.Number(4))
+        self.assertEqual(sc.state_value(), 0)
         sa = mm.get('comp.spec_2_amount')
         self.assertFalse(sa.is_state())
         self.assertEqual(sa.rhs().code(), '4 * comp.size')

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1195,6 +1195,25 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertEqual(mm.get('comp.size').rhs(), myokit.Number(3))
         self.assertFalse(mm.get('comp.size').is_state())
 
+        # Check setting unreferenced value parameter for size
+        sm = sbml.Model()
+        p = sbml.Parameter(sm, 'parameter')
+        c = sm.add_compartment('comp')
+        c.set_value(myokit.Name(p))
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Value for the size of <',
+            sm.myokit_model)
+
+        # Check setting referenced value parameter for size
+        sm = sbml.Model()
+        p = sm.add_parameter('parameter')
+        c = sm.add_compartment('comp')
+        c.set_value(myokit.Name(p))
+        mm = sm.myokit_model()
+        self.assertTrue(mm.has_component('comp'))
+        self.assertEqual(mm.get('comp.size').rhs().code(), 'myokit.parameter')
+        self.assertFalse(mm.get('comp.size').is_state())
+
         # Check setting size as rate
         sm = sbml.Model()
         c = sm.add_compartment('comp')

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1185,44 +1185,15 @@ class SBMLTestMyokitModel(unittest.TestCase):
             '</sbml>'
         )
 
-    def test_add_compartments(self):
+    def test_compartments(self):
         # Tests whether compartments are added properly to the myokit model.
-
-        # Create inputs
-        myokit_model = myokit.Model()
-        component_references = {}
-        variable_references = {}
-        expression_references = {}
-
-        # Create sbml.Model with one compartment
-        m = sbml.Model(name='model')
-        sid = 'compartment'
-        c = m.add_compartment(sid)
-        unit = myokit.units.L
-        c.set_size_units(unit)
-
-        # Add compartment to myokit model
-        m._add_compartments(
-            myokit_model, component_references, variable_references,
-            expression_references)
-
-        # Check that compartment was added properly
-        self.assertTrue(myokit_model.has_component(sid))
-        self.assertIsInstance(component_references[sid], myokit.Component)
-
-        # Check size variable is set properly
-        self.assertIn(sid, variable_references.keys())
-        var = variable_references[sid]
-        self.assertIsInstance(var, myokit.Variable)
-        self.assertEqual(var.unit(), unit)
-        self.assertEqual(
-            expression_references[myokit.Name(c)], myokit.Name(var))
 
         # Check setting size as initial value
         sm = sbml.Model()
         c = sm.add_compartment('comp')
         c.set_initial_value(myokit.Number(2))
         mm = sm.myokit_model()
+        self.assertTrue(mm.has_component('comp'))
         self.assertEqual(mm.get('comp.size').rhs(), myokit.Number(2))
         self.assertFalse(mm.get('comp.size').is_state())
 
@@ -1242,53 +1213,226 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertEqual(mm.get('comp.size').rhs(), myokit.Number(1.5))
         self.assertTrue(mm.get('comp.size').is_state())
 
-    def test_add_myokit_component(self):
-        # Tests whether myokit component is added properly to the myokit model.
+    def test_name(self):
 
-        # Create inputs
-        myokit_model = myokit.Model()
-        component_references = {}
+        # Test regular name
+        name = 'model'
+        m = sbml.Model(name=name)
+        m = m.myokit_model()
 
-        # Create sbml.Model
-        m = sbml.Model(name='model')
+        self.assertEqual(m.name(), name)
 
-        # Add component to myokit model
-        m._add_myokit_component(myokit_model, component_references)
+        # Test name with leading underscore
+        name = '_model'
+        m = sbml.Model(name=name)
+        m = m.myokit_model()
 
-        # Check that myokit component exists
-        sid = 'myokit'
-        self.assertTrue(myokit_model.has_component(sid))
-        self.assertIsInstance(component_references[sid], myokit.Component)
+        self.assertEqual(m.name(), 'underscore' + name)
 
-    def test_add_parameters(self):
-        # Tests whether parameters are added properly to myokit component.
+    def test_notes(self):
 
-        # Create myokit component
-        myokit_model = myokit.Model()
-        component_references = {}
-        m = sbml.Model(name='model')
-        m._add_myokit_component(myokit_model, component_references)
-        c = component_references['myokit']
+        # Test that notes are set as meta data
+        n = 'These are some notes'
+        m = sbml.Model()
+        m.set_notes(n)
+        m = m.myokit_model()
 
-        # Create remaining inputs
-        variable_references = {}
-        expression_references = {}
+        self.assertEqual(m.meta['desc'], n)
 
-        # Add parameter to sbml.Model
-        sid = 'parameter'
-        p = m.add_parameter(sid)
-        unit = myokit.units.A
-        p.set_units(unit)
+    def test_parameters(self):
+        # Tests if parameters are converted
 
-        # Add parameter to myokit model
-        m._add_parameters(c, variable_references, expression_references)
+        m = sbml.Model()
+        m.add_parameter('z')
+        m.add_parameter('boat')
+        m.add_parameter('c')
+        m = m.myokit_model()
 
-        # Check that parameter is added properly to myokit component
-        self.assertTrue(c.has_variable(sid))
-        self.assertIn(sid, variable_references.keys())
-        var = variable_references[sid]
-        self.assertIsInstance(var, myokit.Variable)
-        self.assertEqual(var.unit(), unit)
+        # Check that model created parameters in 'myokit' component
+        self.assertTrue(m.has_variable('myokit.z'))
+        self.assertTrue(m.has_variable('myokit.boat'))
+        self.assertTrue(m.has_variable('myokit.c'))
+
+        # Check that total number of parameters is 4 (3 parameters and time)
+        self.assertEqual(m.count_variables(), 4)
+
+    def test_parameters_initial_value(self):
+        # Tests adding parameters set with initial values
+
+        m = sbml.Model()
+        p = m.add_parameter('param')
+        p.set_initial_value(myokit.Number(7))
+        mm = m.myokit_model()
+        pp = mm.get('myokit.param')
+        self.assertFalse(pp.is_state())
+        self.assertEqual(pp.rhs(), myokit.Number(7))
+
+        # Test units
+        self.assertIsNone(pp.unit())
+        p.set_units(myokit.units.pF)
+        mm = m.myokit_model()
+        pp = mm.get('myokit.param')
+        self.assertFalse(pp.is_state())
+        self.assertEqual(pp.rhs(), myokit.Number(7))
+        self.assertEqual(pp.unit(), myokit.units.pF)
+
+    def test_parameters_values(self):
+        # Tests adding parameters set with a value (non-state)
+
+        m = sbml.Model()
+        p = m.add_parameter('param')
+        p.set_value(myokit.Plus(myokit.Number(7), myokit.Number(3)))
+        mm = m.myokit_model()
+        pp = mm.get('myokit.param')
+        self.assertFalse(pp.is_state())
+        self.assertEqual(
+            pp.rhs(), myokit.Plus(myokit.Number(7), myokit.Number(3)))
+
+        # Test units
+        self.assertIsNone(pp.unit())
+        p.set_units(myokit.units.pF)
+        mm = m.myokit_model()
+        pp = mm.get('myokit.param')
+        self.assertFalse(pp.is_state())
+        self.assertEqual(pp.rhs().code(), '7 + 3')
+        self.assertEqual(pp.unit(), myokit.units.pF)
+
+    def test_parameter_values_rate(self):
+        # Tests adding parameters set with a value (state)
+
+        m = sbml.Model()
+        p = m.add_parameter('param')
+        p.set_value(myokit.Number(3.2), is_rate=True)
+        mm = m.myokit_model()
+        pp = mm.get('myokit.param')
+        self.assertTrue(pp.is_state())
+        self.assertEqual(pp.rhs(), myokit.Number(3.2))
+        self.assertEqual(pp.state_value(), 0)
+
+        # With initial value
+        p.set_initial_value(myokit.Number(1))
+        mm = m.myokit_model()
+        pp = mm.get('myokit.param')
+        self.assertTrue(pp.is_state())
+        self.assertEqual(pp.rhs(), myokit.Number(3.2))
+        self.assertEqual(pp.state_value(), 1)
+
+        # Test units
+        self.assertIsNone(pp.unit())
+        p.set_units(myokit.units.pF)
+        mm = m.myokit_model()
+        pp = mm.get('myokit.param')
+        self.assertTrue(pp.is_state())
+        self.assertEqual(pp.rhs(), myokit.Number(3.2))
+        self.assertEqual(pp.unit(), myokit.units.pF)
+
+    def test_species(self):
+        # Tests whether species initialisation in amount and concentration
+        # works.
+
+        # Species in amount
+        m = sbml.Model()
+        c = m.add_compartment('c')
+        s1 = m.add_species(c, 's1', is_amount=True)
+        mm = m.myokit_model()
+
+        # Check whether species exists in amount
+        self.assertTrue(mm.has_variable('c.s1_amount'))
+        self.assertFalse(mm.has_variable('c.s1_concentration'))
+
+        # Check that component has 2 variables (compartment size and s1 amount)
+        self.assertEqual(mm.get('c').count_variables(), 2)
+
+        # Species in concentration
+        s2 = m.add_species(c, 's2', is_amount=False)
+        mm = m.myokit_model()
+
+        # Check whether species exists in amount and concentration
+        self.assertTrue(mm.has_variable('c.s2_amount'))
+        self.assertTrue(mm.has_variable('c.s2_concentration'))
+
+        # Check that component now has 4 variables
+        self.assertEqual(mm.get('c').count_variables(), 4)
+
+    def test_species_initial_value(self):
+        # Tests converting setting species defined through an initial value
+
+        # Species in amount
+        m = sbml.Model()
+        c = m.add_compartment('comp')
+        s1 = m.add_species(c, 'spec_1', is_amount=True)
+        s1.set_initial_value(myokit.Number(3))
+        mm = m.myokit_model()
+        ms = mm.get('comp.spec_1_amount')
+        self.assertFalse(ms.is_state())
+        self.assertEqual(ms.rhs(), myokit.Number(3))
+
+        # Species in concentration
+        s2 = m.add_species(c, 'spec_2', is_amount=False)
+        s2.set_initial_value(myokit.Number(4))
+        mm = m.myokit_model()
+        sc = mm.get('comp.spec_2_concentration')
+        self.assertFalse(ms.is_state())
+        self.assertEqual(ms.rhs(), myokit.Number(4))
+        sa = mm.get('comp.spec_2_amount')
+        self.assertFalse(sa.is_state())
+        self.assertEqual(sa.rhs().code(), '4 * comp.size')
+
+    def test_species_value(self):
+        # Tests converting setting species defined through a normal equation
+
+        # Species in amount
+        m = sbml.Model()
+        c = m.add_compartment('comp')
+        s1 = m.add_species(c, 'spec_1', is_amount=True)
+        s1.set_value(myokit.Number(3))
+        mm = m.myokit_model()
+        ms = mm.get('comp.spec_1_amount')
+        self.assertFalse(ms.is_state())
+        self.assertEqual(ms.rhs(), myokit.Number(3))
+
+        # Species in concentration
+        s2 = m.add_species(c, 'spec_2', is_amount=False)
+        s2.set_value(myokit.Number(4))
+        mm = m.myokit_model()
+        sc = mm.get('comp.spec_2_concentration')
+        self.assertFalse(ms.is_state())
+        self.assertEqual(ms.rhs(), myokit.Number(4))
+        sa = mm.get('comp.spec_2_amount')
+        self.assertFalse(sa.is_state())
+        self.assertEqual(sa.rhs().code(), '4 * comp.size')
+
+    def test_species_value_rate (self):
+        # Tests converting setting species defined through an ODE equation
+
+        # Species in amount
+        m = sbml.Model()
+        c = m.add_compartment('comp')
+        s1 = m.add_species(c, 'spec_1', is_amount=True)
+        s1.set_value(myokit.Number(3), is_rate=True)
+        mm = m.myokit_model()
+        ms = mm.get('comp.spec_1_amount')
+        self.assertTrue(ms.is_state())
+        self.assertEqual(ms.rhs(), myokit.Number(3))
+        self.assertEqual(ms.state_value(), 0)
+        s1.set_initial_value(myokit.Number(7))
+        mm = m.myokit_model()
+        ms = mm.get('comp.spec_1_amount')
+        self.assertTrue(ms.is_state())
+        self.assertEqual(ms.rhs(), myokit.Number(3))
+        self.assertEqual(ms.state_value(), 7)
+
+        # Species in concentration
+        s2 = m.add_species(c, 'spec_2', is_amount=False)
+        s2.set_value(myokit.Number(4), is_rate=True)
+        mm = m.myokit_model()
+        sc = mm.get('comp.spec_2_concentration')
+        self.assertTruee(ms.is_state())
+        self.assertEqual(ms.rhs(), myokit.Number(4))
+        self.assertEqual(ms.state_value(), 0)
+        sa = mm.get('comp.spec_2_amount')
+        self.assertFalse(sa.is_state())
+        self.assertEqual(sa.rhs().code(), '4 * comp.size')
 
     def test_add_species(self):
         # Tests whether species are added properly to the associated
@@ -1371,178 +1515,6 @@ class SBMLTestMyokitModel(unittest.TestCase):
         var = species_amount_references[sid]
         self.assertEqual(var.unit(), s_unit)
 
-    def test_add_stoichiometries(self):
-        # Tests whether stoichiometries are added properly to the associated
-        # component.
-
-        # Add compartment and species to myokit model
-        myokit_model = myokit.Model()
-        component_references = {}
-        variable_references = {}
-        expression_references = {}
-        species_amount_references = {}
-
-        m = sbml.Model(name='model')
-        c_sid = 'compartment'
-        c = m.add_compartment(c_sid)
-
-        m._add_compartments(
-            myokit_model, component_references, variable_references,
-            expression_references)
-
-        sid = 'species'
-        s = m.add_species(c, sid)
-
-        m._add_species(
-            component_references, species_amount_references,
-            variable_references, expression_references)
-
-        # Case I: No stoichiometry reference
-        # Add reaction to sbml.Model
-        sid = 'reaction'
-        r = m.add_reaction(sid)
-        r_sid = None
-        r.add_reactant(species=s, sid=r_sid)
-        p_sid = None
-        r.add_product(species=s, sid=p_sid)
-
-        # Add stoichiometries to myokit model
-        m._add_stoichiometries(
-            component_references, variable_references, expression_references)
-
-        # Check that stoichiometries do not exist in myokit model and are not
-        # referenced in variable_references
-        comp = component_references[c_sid]
-        self.assertFalse(comp.has_variable(str(r_sid)))
-        self.assertFalse(comp.has_variable(str(p_sid)))
-        self.assertNotIn(r_sid, variable_references.keys())
-        self.assertNotIn(p_sid, variable_references.keys())
-
-        # Case II: Existing stoichiometry reference
-        # Add reaction to sbml.Model
-        sid = 'reaction_2'
-        r = m.add_reaction(sid)
-        r_sid = 'reactant'
-        rs = r.add_reactant(species=s, sid=r_sid)
-        p_sid = 'product'
-        ps = r.add_product(species=s, sid=p_sid)
-
-        # Add stoichiometries to myokit model
-        m._add_stoichiometries(
-            component_references, variable_references, expression_references)
-
-        # Check that stoichiometries exist in myokit model and are
-        # referenced in variable_references
-        comp = component_references[c_sid]
-        self.assertTrue(comp.has_variable(str(r_sid)))
-        self.assertTrue(comp.has_variable(str(p_sid)))
-        self.assertIn(r_sid, variable_references.keys())
-        self.assertIn(p_sid, variable_references.keys())
-
-        # Check that their units are set to dimensionless
-        # and that their expressions are referenced
-        unit = myokit.units.dimensionless
-        var = variable_references[r_sid]
-        self.assertEqual(var.unit(), unit)
-        self.assertEqual(
-            expression_references[myokit.Name(rs)], myokit.Name(var))
-        var = variable_references[p_sid]
-        self.assertEqual(var.unit(), unit)
-        self.assertEqual(
-            expression_references[myokit.Name(ps)], myokit.Name(var))
-
-        # Check that stoichiometries are referenced in
-
-    def test_add_time(self):
-        # Tests whether time bound variable is added properly to myokit
-        # component.
-
-        # Create myokit component
-        myokit_model = myokit.Model()
-        component_references = {}
-        m = sbml.Model(name='model')
-        m._add_myokit_component(myokit_model, component_references)
-        c = component_references['myokit']
-
-        # Create remaining inputs
-        variable_references = {}
-
-        # Add time bound variable to myokit model
-        unit = myokit.units.s
-        m.set_time_units(unit)
-        m._add_time(c, variable_references)
-
-        # Check that time bound variable exists in myokit component
-        self.assertTrue(c.has_variable('time'))
-
-        # Check that variable is referenced under csymbol
-        sid = 'http://www.sbml.org/sbml/symbols/time'
-        self.assertIn(sid, variable_references.keys())
-
-        # Check that variable has correct units and initial value
-        var = variable_references[sid]
-        self.assertEqual(var.rhs(), myokit.Number(0))
-        self.assertEqual(var.unit(), unit)
-
-    def test_name(self):
-
-        # Test regular name
-        name = 'model'
-        m = sbml.Model(name=name)
-        m = m.myokit_model()
-
-        self.assertEqual(m.name(), name)
-
-        # Test name with leading underscore
-        name = '_model'
-        m = sbml.Model(name=name)
-        m = m.myokit_model()
-
-        self.assertEqual(m.name(), 'underscore' + name)
-
-    def test_notes(self):
-
-        # Test that notes are set as meta data
-        n = 'These are some notes'
-        m = sbml.Model()
-        m.set_notes(n)
-        m = m.myokit_model()
-
-        self.assertEqual(m.meta['desc'], n)
-
-    def test_species_exist(self):
-        # Tests whether species initialisation in amount and concentration
-        # works.
-
-        # Species in amount
-        m = sbml.Model()
-        c = m.add_compartment('c')
-        s = m.add_species(c, 'spec', is_amount=True)
-        m = m.myokit_model()
-
-        # Check whether species exists in amount
-        self.assertTrue(m.has_variable('c.spec_amount'))
-
-        # Check that component has 2 variables
-        # [size, spec_amount]
-        component = m.get('c')
-        self.assertEqual(component.count_variables(), 2)
-
-        # Species in concentration
-        m = sbml.Model()
-        c = m.add_compartment('c')
-        s = m.add_species(c, 'spec', is_amount=False)
-        m = m.myokit_model()
-
-        # Check whether species exists in amount and concentration
-        self.assertTrue(m.has_variable('c.spec_amount'))
-        self.assertTrue(m.has_variable('c.spec_concentration'))
-
-        # Check that component has 3 variables
-        # [size, spec_amount, spec_concentration]
-        component = m.get('c')
-        self.assertEqual(component.count_variables(), 3)
-
     def test_species_units(self):
         # Tests whether species units are set properly.
 
@@ -1564,455 +1536,6 @@ class SBMLTestMyokitModel(unittest.TestCase):
         conc = mm.get('c.spec_concentration')
         self.assertEqual(amount.unit(), myokit.units.kg)
         self.assertEqual(conc.unit(), myokit.units.kg / myokit.units.meter)
-
-    def test_species_initial_values(self):
-        # Tests whether initial values of species is set properly.
-        a = ('<model>'
-             '  <listOfCompartments>'
-             '    <compartment id="c" size="10"/>'
-             '  </listOfCompartments>'
-             '  <listOfSpecies>'
-             '    <species compartment="c" id="spec"'
-             '      initialConcentration="2.1"/>'
-             '  </listOfSpecies>')
-        b = ('</model>')
-
-        # Test I: Set by species
-        m = self.parse(a + b)
-        m = m.myokit_model()
-
-        # Check that intial values are set
-        amount = m.get('c.spec_amount')
-        conc = m.get('c.spec_concentration')
-
-        self.assertEqual(amount.eval(), 21)
-        self.assertEqual(conc.eval(), 2.1)
-
-        # Test II: Set by initialAssignment
-        x = ('<listOfInitialAssignments>'
-             '  <initialAssignment symbol="spec">'
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <cn>5</cn>'
-             '    </math>'
-             '  </initialAssignment>'
-             '</listOfInitialAssignments>')
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that intial values are set
-        amount = m.get('c.spec_amount')
-        conc = m.get('c.spec_concentration')
-
-        self.assertEqual(amount.eval(), 50)
-        self.assertEqual(conc.eval(), 5)
-
-    def test_species_values(self):
-        # Tests whether values of species is set properly. This does not
-        # include rate expressions from reactions.
-
-        a = ('<model>'
-             '  <listOfCompartments>'
-             '    <compartment id="c" size="10"/>'
-             '  </listOfCompartments>'
-             '  <listOfSpecies>'
-             '    <species compartment="c" id="spec"'
-             '      initialConcentration="2.1" boundaryCondition="true"/>'
-             '  </listOfSpecies>')
-        b = ('</model>')
-
-        # Test I: Set by assignmentRule
-        x = ('<listOfRules>'
-             '  <assignmentRule variable="spec"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <plus/>'
-             '        <ci> c </ci>'
-             '        <cn> 5 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </assignmentRule>'
-             '</listOfRules>')
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that values are set
-        amount = m.get('c.spec_amount')
-        conc = m.get('c.spec_concentration')
-
-        self.assertEqual(amount.eval(), 150)
-        self.assertEqual(conc.eval(), 15)
-
-        # Test II: Set by rateRule
-        x = ('<listOfRules>'
-             '  <rateRule variable="spec"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <plus/>'
-             '        <ci> c </ci>'
-             '        <cn> 5 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </rateRule>'
-             '</listOfRules>')
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that intial values are set
-        damount = m.get('c.spec_amount')
-        conc = m.get('c.spec_concentration')
-
-        self.assertEqual(damount.eval(), 150)
-        self.assertEqual(conc.eval(), 2.1)
-
-    def test_parameter_exist(self):
-        # Tests whether initialisation of parameters works properly.
-
-        a = '<model><listOfParameters>'
-        b = '</listOfParameters></model>'
-
-        x = '<parameter id="a" /><parameter id="b" />'
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that model created parameters in 'myokit' component
-        self.assertTrue(m.has_variable('myokit.a'))
-        self.assertTrue(m.has_variable('myokit.b'))
-
-        # Check that total number of parameters is 3
-        # [a, b, time]
-        self.assertEqual(m.count_variables(), 3)
-
-    def test_parameter_units(self):
-        # Tests whether parameter units are set properly.
-
-        a = '<model><listOfParameters>'
-        b = '</listOfParameters></model>'
-
-        x = ('<parameter id="c" value="2" />'
-             '<parameter id="d" units="volt" />'
-             '<parameter id="e" units="ampere" value="-1.2e-3" />')
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Get parameters
-        c = m.get('myokit.c')
-        d = m.get('myokit.d')
-        e = m.get('myokit.e')
-
-        # Check that units are set properly
-        self.assertIsNone(c.unit())
-        self.assertEqual(d.unit(), myokit.units.volt)
-        self.assertEqual(e.unit(), myokit.units.ampere)
-
-    def test_parameter_initial_values(self):
-        # Tests whether initial values of parameters are set correctly.
-
-        a = '<model>'
-        b = '</model>'
-
-        # Test I: Initial value set by parameter
-        x = '<listOfParameters>' + \
-            '  <parameter id="V" value="1.2">' + \
-            '  </parameter>' + \
-            '</listOfParameters>'
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check initial value of parameter
-        var = m.get('myokit.V')
-        self.assertEqual(var.eval(), 1.2)
-
-        # Test II: Initial value set by initialAssignment
-        x = '<listOfParameters>' + \
-            '  <parameter id="V" value="1.2">' + \
-            '  </parameter>' + \
-            '</listOfParameters>' + \
-            '<listOfInitialAssignments>' + \
-            '  <initialAssignment symbol="V">' + \
-            '    <math xmlns="http://www.w3.org/1998/Math/MathML">' + \
-            '      <cn>5</cn>' + \
-            '    </math>' + \
-            '  </initialAssignment>' + \
-            '</listOfInitialAssignments>'
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check initial value of parameter
-        var = m.get('myokit.V')
-        self.assertEqual(var.eval(), 5)
-
-    def test_parameter_values(self):
-        # Tests whether values of parameters are set correctly.
-
-        a = '<model>' + \
-            '  <listOfParameters>' + \
-            '    <parameter id="V" value="1.2">' + \
-            '    </parameter>' + \
-            '    <parameter id="K" value="3">' + \
-            '    </parameter>' + \
-            '  </listOfParameters>'
-        b = '</model>'
-
-        # Test I: Set by assignmentRule
-        x = '<listOfRules>' + \
-            '  <assignmentRule variable="V"> ' + \
-            '    <math xmlns="http://www.w3.org/1998/Math/MathML">' + \
-            '      <apply>' + \
-            '        <plus/>' + \
-            '        <ci> K </ci>' + \
-            '        <cn> 5 </cn>' + \
-            '      </apply>' + \
-            '    </math>' + \
-            '  </assignmentRule>' + \
-            '</listOfRules>'
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check value of parameter
-        var = m.get('myokit.V')
-        self.assertEqual(var.eval(), 8)
-
-        # Test II: Set by rateRule
-        x = '<listOfRules>' + \
-            '  <rateRule variable="V"> ' + \
-            '    <math xmlns="http://www.w3.org/1998/Math/MathML">' + \
-            '      <apply>' + \
-            '        <plus/>' + \
-            '        <ci> V </ci>' + \
-            '        <cn> 5 </cn>' + \
-            '      </apply>' + \
-            '    </math>' + \
-            '  </rateRule>' + \
-            '</listOfRules>'
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that parameter is state variable
-        var = m.get('myokit.V')
-        self.assertTrue(var.is_state())
-
-        # Check value of parameter
-        self.assertEqual(var.eval(), 6.2)
-
-    def test_stoichiometries_exist(self):
-        # Tests whether stoichiometries are created properly.
-
-        a = ('<model>'
-             ' <listOfCompartments>'
-             '  <compartment id="c" size="1.2" />'
-             ' </listOfCompartments>'
-             ' <listOfSpecies>'
-             '  <species id="s1" compartment="c" />'
-             '  <species id="s2" compartment="c" />'
-             ' </listOfSpecies>'
-             ' <listOfReactions>'
-             '  <reaction id="r">'
-             '   <listOfReactants>'
-             '    <speciesReference species="s1" id="sr" />'
-             '   </listOfReactants>'
-             '   <listOfProducts>'
-             '    <speciesReference species="s2" id="sp" />'
-             '   </listOfProducts>'
-             '   <kineticLaw>'
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <apply>'
-             '      <plus/>'
-             '      <ci>s1</ci>'
-             '      <ci>s2</ci>'
-             '     </apply>'
-             '    </math>'
-             '   </kineticLaw>'
-             '  </reaction>'
-             ' </listOfReactions>')
-        b = ('</model>')
-
-        m = self.parse(a + b)
-        m = m.myokit_model()
-
-        # Check that stoichiometry variables exists
-        self.assertTrue(m.has_variable('c.sr'))
-        self.assertTrue(m.has_variable('c.sp'))
-
-    def test_stoichiometries_initial_value(self):
-        # Tests whether initial values of stoichiometries are set properly.
-
-        a = ('<model>'
-             ' <listOfCompartments>'
-             '  <compartment id="c" size="1.2" />'
-             ' </listOfCompartments>'
-             ' <listOfSpecies>'
-             '  <species id="s1" compartment="c" />'
-             '  <species id="s2" compartment="c" />'
-             ' </listOfSpecies>'
-             ' <listOfReactions>'
-             '  <reaction id="r">'
-             '   <listOfReactants>'
-             '    <speciesReference species="s1" id="sr" stoichiometry="2.1"/>'
-             '   </listOfReactants>'
-             '   <listOfProducts>'
-             '    <speciesReference species="s2" id="sp" stoichiometry="3.5"/>'
-             '   </listOfProducts>'
-             '   <kineticLaw>'
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <apply>'
-             '      <plus/>'
-             '      <ci>s1</ci>'
-             '      <ci>s2</ci>'
-             '     </apply>'
-             '    </math>'
-             '   </kineticLaw>'
-             '  </reaction>'
-             ' </listOfReactions>')
-        b = ('</model>')
-
-        # Test I: Set by speciesReference
-        m = self.parse(a + b)
-        m = m.myokit_model()
-
-        # Check that initial values are set properly
-        stoich_reactant = m.get('c.sr')
-        stoich_product = m.get('c.sp')
-
-        self.assertEqual(stoich_reactant.eval(), 2.1)
-        self.assertEqual(stoich_product.eval(), 3.5)
-
-        # Test I: Set by initialAssignment
-        x = (' <listOfInitialAssignments>'
-             '  <initialAssignment symbol="sr">'
-             '   <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <cn>4.51</cn>'
-             '   </math>'
-             '  </initialAssignment>'
-             '  <initialAssignment symbol="sp">'
-             '   <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <cn>6</cn>'
-             '   </math>'
-             '  </initialAssignment>'
-             ' </listOfInitialAssignments>')
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that initial values are set properly
-        stoich_reactant = m.get('c.sr')
-        stoich_product = m.get('c.sp')
-
-        self.assertEqual(stoich_reactant.eval(), 4.51)
-        self.assertEqual(stoich_product.eval(), 6)
-
-    def test_stoichiometry_values(self):
-        # Tests whether values of parameters are set correctly.
-
-        a = ('<model>'
-             ' <listOfCompartments>'
-             '  <compartment id="c" size="1.2" />'
-             ' </listOfCompartments>'
-             ' <listOfParameters>'
-             '  <parameter id="V" value="10.23">'
-             '  </parameter>'
-             ' </listOfParameters>'
-             ' <listOfSpecies>'
-             '  <species id="s1" compartment="c" />'
-             '  <species id="s2" compartment="c" />'
-             ' </listOfSpecies>'
-             ' <listOfReactions>'
-             '  <reaction id="r">'
-             '   <listOfReactants>'
-             '    <speciesReference species="s1" id="sr" stoichiometry="2.1"/>'
-             '   </listOfReactants>'
-             '   <listOfProducts>'
-             '    <speciesReference species="s2" id="sp" stoichiometry="3.5"/>'
-             '   </listOfProducts>'
-             '   <kineticLaw>'
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <apply>'
-             '      <plus/>'
-             '      <ci>s1</ci>'
-             '      <ci>s2</ci>'
-             '     </apply>'
-             '    </math>'
-             '   </kineticLaw>'
-             '  </reaction>'
-             ' </listOfReactions>')
-        b = ('</model>')
-
-        # Test I: Set by assignmentRule
-        x = ('<listOfRules>'
-             '  <assignmentRule variable="sr"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <plus/>'
-             '        <ci> V </ci>'
-             '        <cn> 5 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </assignmentRule>'
-             '  <assignmentRule variable="sp"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <plus/>'
-             '        <ci> V </ci>'
-             '        <cn> 3.81 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </assignmentRule>'
-             '</listOfRules>')
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check value of stoichiometries
-        var = m.get('c.sr')
-        self.assertEqual(var.eval(), 15.23)
-
-        var = m.get('c.sp')
-        self.assertAlmostEqual(var.eval(), 14.04)
-
-        # Test II: Set by rateRule
-        x = ('<listOfRules>'
-             '  <rateRule variable="sr"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <plus/>'
-             '        <ci> V </ci>'
-             '        <cn> 3 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </rateRule>'
-             '  <rateRule variable="sp"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <minus/>'
-             '        <ci> V </ci>'
-             '        <cn> 1 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </rateRule>'
-             '</listOfRules>')
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that stoichiometries are state variables
-        var = m.get('c.sr')
-        self.assertTrue(var.is_state())
-
-        var = m.get('c.sp')
-        self.assertTrue(var.is_state())
-
-        # Check value of stoichiometries
-        var = m.get('c.sr')
-        self.assertEqual(var.eval(), 13.23)
-
-        var = m.get('c.sp')
-        self.assertEqual(var.eval(), 9.23)
 
     def test_reaction_expression(self):
         # Tests whether species reaction rate expressions are set correctly.
@@ -2063,7 +1586,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         var = m.get('c.s2_amount')
         self.assertEqual(var.eval(), 2 / 1.2 + 1.5)
 
-    def test_reaction_no_kinteic_law(self):
+    def test_reaction_no_kinetic_law(self):
         # Tests whether missing kinetic law is handled correctly.
 
         a = ('<model>'
@@ -2161,6 +1684,63 @@ class SBMLTestMyokitModel(unittest.TestCase):
 
         var = m.get('c.s3_amount')
         self.assertEqual(var.eval(), 1.2 * 1.5)
+
+    def test_reaction_conversion_factor(self):
+        # Tests whether rate contributions are converted correctly.
+
+        a = ('<model>'
+             ' <listOfCompartments>'
+             '  <compartment id="c" size="1.2" />'
+             ' </listOfCompartments>'
+             ' <listOfParameters>'
+             '  <parameter id="x" value="1.2">'
+             '  </parameter>'
+             '  <parameter id="y" value="3">'
+             '  </parameter>'
+             ' </listOfParameters>'
+             ' <listOfSpecies>'
+             '  <species id="s1" compartment="c" initialAmount="2"'
+             '    conversionFactor="x"/>'
+             '  <species id="s2" compartment="c" initialConcentration="1.5"'
+             '    conversionFactor="y"/>'
+             ' </listOfSpecies>'
+             ' <listOfReactions>'
+             '  <reaction id="r">'
+             '   <listOfReactants>'
+             '    <speciesReference species="s1"/>'
+             '   </listOfReactants>'
+             '   <listOfProducts>'
+             '    <speciesReference species="s2"/>'
+             '   </listOfProducts>'
+             '   <kineticLaw>'
+             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '     <apply>'
+             '      <plus/>'
+             '      <ci>s1</ci>'
+             '      <ci>s2</ci>'
+             '     </apply>'
+             '    </math>'
+             '   </kineticLaw>'
+             '  </reaction>'
+             ' </listOfReactions>')
+        b = ('</model>')
+
+        m = self.parse(a + b)
+        m = m.myokit_model()
+
+        # Check that species are state variables
+        var = m.get('c.s1_amount')
+        self.assertTrue(var.is_state())
+
+        var = m.get('c.s2_amount')
+        self.assertTrue(var.is_state())
+
+        # Check rates
+        var = m.get('c.s1_amount')
+        self.assertEqual(var.eval(), -1.2 * (2 / 1.2 + 1.5))
+
+        var = m.get('c.s2_amount')
+        self.assertEqual(var.eval(), 3 * (2 / 1.2 + 1.5))
 
     def test_reaction_stoichiometry(self):
         # Tests whether stoichiometry is used in reactions correctly.
@@ -2277,32 +1857,24 @@ class SBMLTestMyokitModel(unittest.TestCase):
         var = m.get('c.s2_amount')
         self.assertEqual(var.eval(), 2 * (2 / 1.2 + 1.5))
 
-    def test_reaction_conversion_factor(self):
-        # Tests whether rate contributions are converted correctly.
+    def test_reaction_stoichiometries_exist(self):
+        # Tests whether stoichiometries are created properly.
 
         a = ('<model>'
              ' <listOfCompartments>'
              '  <compartment id="c" size="1.2" />'
              ' </listOfCompartments>'
-             ' <listOfParameters>'
-             '  <parameter id="x" value="1.2">'
-             '  </parameter>'
-             '  <parameter id="y" value="3">'
-             '  </parameter>'
-             ' </listOfParameters>'
              ' <listOfSpecies>'
-             '  <species id="s1" compartment="c" initialAmount="2"'
-             '    conversionFactor="x"/>'
-             '  <species id="s2" compartment="c" initialConcentration="1.5"'
-             '    conversionFactor="y"/>'
+             '  <species id="s1" compartment="c" />'
+             '  <species id="s2" compartment="c" />'
              ' </listOfSpecies>'
              ' <listOfReactions>'
              '  <reaction id="r">'
              '   <listOfReactants>'
-             '    <speciesReference species="s1"/>'
+             '    <speciesReference species="s1" id="sr" />'
              '   </listOfReactants>'
              '   <listOfProducts>'
-             '    <speciesReference species="s2"/>'
+             '    <speciesReference species="s2" id="sp" />'
              '   </listOfProducts>'
              '   <kineticLaw>'
              '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
@@ -2320,25 +1892,271 @@ class SBMLTestMyokitModel(unittest.TestCase):
         m = self.parse(a + b)
         m = m.myokit_model()
 
-        # Check that species are state variables
-        var = m.get('c.s1_amount')
+        # Check that stoichiometry variables exists
+        self.assertTrue(m.has_variable('c.sr'))
+        self.assertTrue(m.has_variable('c.sp'))
+
+    def test_reaction_stoichiometries_initial_value(self):
+        # Tests whether initial values of stoichiometries are set properly.
+
+        a = ('<model>'
+             ' <listOfCompartments>'
+             '  <compartment id="c" size="1.2" />'
+             ' </listOfCompartments>'
+             ' <listOfSpecies>'
+             '  <species id="s1" compartment="c" />'
+             '  <species id="s2" compartment="c" />'
+             ' </listOfSpecies>'
+             ' <listOfReactions>'
+             '  <reaction id="r">'
+             '   <listOfReactants>'
+             '    <speciesReference species="s1" id="sr" stoichiometry="2.1"/>'
+             '   </listOfReactants>'
+             '   <listOfProducts>'
+             '    <speciesReference species="s2" id="sp" stoichiometry="3.5"/>'
+             '   </listOfProducts>'
+             '   <kineticLaw>'
+             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '     <apply>'
+             '      <plus/>'
+             '      <ci>s1</ci>'
+             '      <ci>s2</ci>'
+             '     </apply>'
+             '    </math>'
+             '   </kineticLaw>'
+             '  </reaction>'
+             ' </listOfReactions>')
+        b = ('</model>')
+
+        # Test I: Set by speciesReference
+        m = self.parse(a + b)
+        m = m.myokit_model()
+
+        # Check that initial values are set properly
+        stoich_reactant = m.get('c.sr')
+        stoich_product = m.get('c.sp')
+
+        self.assertEqual(stoich_reactant.eval(), 2.1)
+        self.assertEqual(stoich_product.eval(), 3.5)
+
+        # Test I: Set by initialAssignment
+        x = (' <listOfInitialAssignments>'
+             '  <initialAssignment symbol="sr">'
+             '   <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '     <cn>4.51</cn>'
+             '   </math>'
+             '  </initialAssignment>'
+             '  <initialAssignment symbol="sp">'
+             '   <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '     <cn>6</cn>'
+             '   </math>'
+             '  </initialAssignment>'
+             ' </listOfInitialAssignments>')
+
+        m = self.parse(a + x + b)
+        m = m.myokit_model()
+
+        # Check that initial values are set properly
+        stoich_reactant = m.get('c.sr')
+        stoich_product = m.get('c.sp')
+
+        self.assertEqual(stoich_reactant.eval(), 4.51)
+        self.assertEqual(stoich_product.eval(), 6)
+
+    def test_reaction_stoichiometry_values(self):
+        # Tests whether values of parameters are set correctly.
+
+        a = ('<model>'
+             ' <listOfCompartments>'
+             '  <compartment id="c" size="1.2" />'
+             ' </listOfCompartments>'
+             ' <listOfParameters>'
+             '  <parameter id="V" value="10.23">'
+             '  </parameter>'
+             ' </listOfParameters>'
+             ' <listOfSpecies>'
+             '  <species id="s1" compartment="c" />'
+             '  <species id="s2" compartment="c" />'
+             ' </listOfSpecies>'
+             ' <listOfReactions>'
+             '  <reaction id="r">'
+             '   <listOfReactants>'
+             '    <speciesReference species="s1" id="sr" stoichiometry="2.1"/>'
+             '   </listOfReactants>'
+             '   <listOfProducts>'
+             '    <speciesReference species="s2" id="sp" stoichiometry="3.5"/>'
+             '   </listOfProducts>'
+             '   <kineticLaw>'
+             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '     <apply>'
+             '      <plus/>'
+             '      <ci>s1</ci>'
+             '      <ci>s2</ci>'
+             '     </apply>'
+             '    </math>'
+             '   </kineticLaw>'
+             '  </reaction>'
+             ' </listOfReactions>')
+        b = ('</model>')
+
+        # Test I: Set by assignmentRule
+        x = ('<listOfRules>'
+             '  <assignmentRule variable="sr"> '
+             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '      <apply>'
+             '        <plus/>'
+             '        <ci> V </ci>'
+             '        <cn> 5 </cn>'
+             '      </apply>'
+             '    </math>'
+             '  </assignmentRule>'
+             '  <assignmentRule variable="sp"> '
+             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '      <apply>'
+             '        <plus/>'
+             '        <ci> V </ci>'
+             '        <cn> 3.81 </cn>'
+             '      </apply>'
+             '    </math>'
+             '  </assignmentRule>'
+             '</listOfRules>')
+
+        m = self.parse(a + x + b)
+        m = m.myokit_model()
+
+        # Check value of stoichiometries
+        var = m.get('c.sr')
+        self.assertEqual(var.eval(), 15.23)
+
+        var = m.get('c.sp')
+        self.assertAlmostEqual(var.eval(), 14.04)
+
+        # Test II: Set by rateRule
+        x = ('<listOfRules>'
+             '  <rateRule variable="sr"> '
+             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '      <apply>'
+             '        <plus/>'
+             '        <ci> V </ci>'
+             '        <cn> 3 </cn>'
+             '      </apply>'
+             '    </math>'
+             '  </rateRule>'
+             '  <rateRule variable="sp"> '
+             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
+             '      <apply>'
+             '        <minus/>'
+             '        <ci> V </ci>'
+             '        <cn> 1 </cn>'
+             '      </apply>'
+             '    </math>'
+             '  </rateRule>'
+             '</listOfRules>')
+
+        m = self.parse(a + x + b)
+        m = m.myokit_model()
+
+        # Check that stoichiometries are state variables
+        var = m.get('c.sr')
         self.assertTrue(var.is_state())
 
-        var = m.get('c.s2_amount')
+        var = m.get('c.sp')
         self.assertTrue(var.is_state())
 
-        # Check rates
-        var = m.get('c.s1_amount')
-        self.assertEqual(var.eval(), -1.2 * (2 / 1.2 + 1.5))
+        # Check value of stoichiometries
+        var = m.get('c.sr')
+        self.assertEqual(var.eval(), 13.23)
 
-        var = m.get('c.s2_amount')
-        self.assertEqual(var.eval(), 3 * (2 / 1.2 + 1.5))
+        var = m.get('c.sp')
+        self.assertEqual(var.eval(), 9.23)
+
+    def test_reaction_stoichiometries(self):
+        # Tests whether stoichiometries are added properly to the associated
+        # component.
+
+        # Add compartment and species to myokit model
+        myokit_model = myokit.Model()
+        component_references = {}
+        variable_references = {}
+        expression_references = {}
+        species_amount_references = {}
+
+        m = sbml.Model(name='model')
+        c_sid = 'compartment'
+        c = m.add_compartment(c_sid)
+
+        m._add_compartments(
+            myokit_model, component_references, variable_references,
+            expression_references)
+
+        sid = 'species'
+        s = m.add_species(c, sid)
+
+        m._add_species(
+            component_references, species_amount_references,
+            variable_references, expression_references)
+
+        # Case I: No stoichiometry reference
+        # Add reaction to sbml.Model
+        sid = 'reaction'
+        r = m.add_reaction(sid)
+        r_sid = None
+        r.add_reactant(species=s, sid=r_sid)
+        p_sid = None
+        r.add_product(species=s, sid=p_sid)
+
+        # Add stoichiometries to myokit model
+        m._add_stoichiometries(
+            component_references, variable_references, expression_references)
+
+        # Check that stoichiometries do not exist in myokit model and are not
+        # referenced in variable_references
+        comp = component_references[c_sid]
+        self.assertFalse(comp.has_variable(str(r_sid)))
+        self.assertFalse(comp.has_variable(str(p_sid)))
+        self.assertNotIn(r_sid, variable_references.keys())
+        self.assertNotIn(p_sid, variable_references.keys())
+
+        # Case II: Existing stoichiometry reference
+        # Add reaction to sbml.Model
+        sid = 'reaction_2'
+        r = m.add_reaction(sid)
+        r_sid = 'reactant'
+        rs = r.add_reactant(species=s, sid=r_sid)
+        p_sid = 'product'
+        ps = r.add_product(species=s, sid=p_sid)
+
+        # Add stoichiometries to myokit model
+        m._add_stoichiometries(
+            component_references, variable_references, expression_references)
+
+        # Check that stoichiometries exist in myokit model and are
+        # referenced in variable_references
+        comp = component_references[c_sid]
+        self.assertTrue(comp.has_variable(str(r_sid)))
+        self.assertTrue(comp.has_variable(str(p_sid)))
+        self.assertIn(r_sid, variable_references.keys())
+        self.assertIn(p_sid, variable_references.keys())
+
+        # Check that their units are set to dimensionless
+        # and that their expressions are referenced
+        unit = myokit.units.dimensionless
+        var = variable_references[r_sid]
+        self.assertEqual(var.unit(), unit)
+        self.assertEqual(
+            expression_references[myokit.Name(rs)], myokit.Name(var))
+        var = variable_references[p_sid]
+        self.assertEqual(var.unit(), unit)
+        self.assertEqual(
+            expression_references[myokit.Name(ps)], myokit.Name(var))
+
+        # Check that stoichiometries are referenced in
 
     def test_time(self):
         # Tests whether time variable is created properly.
 
         m = sbml.Model()
-        m.set_time_units(myokit.units.s)
+        m.set_time_units(myokit.units.ampere)
         m = m.myokit_model()
 
         # Check that time variable exists
@@ -2346,13 +2164,44 @@ class SBMLTestMyokitModel(unittest.TestCase):
 
         # Check that unit is set
         var = m.get('myokit.time')
-        self.assertEqual(var.unit(), myokit.units.second)
+        self.assertEqual(var.unit(), myokit.units.ampere)
 
         # Check that initial value is set
         self.assertEqual(var.eval(), 0)
 
         # Chet that variable is time bound
         self.assertTrue(var.binding(), 'time')
+
+    def test_time_2(self):
+        # Tests whether time bound variable is added properly to myokit
+        # component.
+
+        # Create myokit component
+        myokit_model = myokit.Model()
+        component_references = {}
+        m = sbml.Model(name='model')
+        m._add_myokit_component(myokit_model, component_references)
+        c = component_references['myokit']
+
+        # Create remaining inputs
+        variable_references = {}
+
+        # Add time bound variable to myokit model
+        unit = myokit.units.s
+        m.set_time_units(unit)
+        m._add_time(c, variable_references)
+
+        # Check that time bound variable exists in myokit component
+        self.assertTrue(c.has_variable('time'))
+
+        # Check that variable is referenced under csymbol
+        sid = 'http://www.sbml.org/sbml/symbols/time'
+        self.assertIn(sid, variable_references.keys())
+
+        # Check that variable has correct units and initial value
+        var = variable_references[sid]
+        self.assertEqual(var.rhs(), myokit.Number(0))
+        self.assertEqual(var.unit(), unit)
 
 
 if __name__ == '__main__':

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -502,6 +502,659 @@ class TestModel(unittest.TestCase):
         self.assertEqual(model.volume_units(), myokit.units.L)
 
 
+class TestParameter(unittest.TestCase):
+    """
+    Unit tests for :class:`Parameter`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = sbml.Model(name='model')
+        cls.sid = 'parameter'
+        cls.p = cls.model.add_parameter(sid=cls.sid)
+
+    def test_bad_model(self):
+
+        model = 'model'
+        sid = 'parameter'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', sbml.Parameter, model, sid)
+
+    def test_initial_value(self):
+
+        # Check default initial value
+        self.assertIsNone(self.p.initial_value())
+
+        # Check bad value
+        expr = 2
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.p.set_initial_value, expr)
+
+        # Check good value
+        expr = myokit.Number(2)
+        self.p.set_initial_value(expr)
+
+        self.assertEqual(self.p.initial_value(), expr)
+
+    def test_is_rate(self):
+
+        # Check default
+        self.assertFalse(self.p.is_rate())
+
+        # Check setting rate to true
+        expr = myokit.Number(2)
+        self.p.set_value(value=expr, is_rate=True)
+
+        self.assertTrue(self.p.is_rate())
+
+    def test_sid(self):
+        self.assertEqual(self.p.sid(), self.sid)
+
+    def test_string_representation(self):
+        self.assertEqual(str(self.p), '<Parameter ' + self.sid + '>')
+
+    def test_units(self):
+
+        # Check default units
+        self.assertIsNone(self.p.units())
+
+        # Check bad size units
+        unit = 'mL'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.p.set_units, unit)
+
+        # Check valid size units
+        unit = myokit.units.L * 1E-3
+        self.p.set_units(unit)
+
+        self.assertEqual(self.p.units(), unit)
+
+    def test_value(self):
+
+        # Check bad value
+        expr = 2
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.p.set_value, expr)
+
+        # Check good value
+        expr = myokit.Number(2)
+        self.p.set_value(expr)
+
+        self.assertEqual(self.p.value(), expr)
+
+
+class TestReaction(unittest.TestCase):
+    """
+    Unit tests for :class:`Reaction`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = sbml.Model(name='model')
+        cls.sid = 'reaction'
+        cls.r = cls.model.add_reaction(sid=cls.sid)
+
+    def test_bad_model(self):
+
+        model = 'model'
+        sid = 'reaction'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', sbml.Reaction, model, sid)
+
+    def test_kinetic_law(self):
+
+        # Check default
+        self.assertIsNone(self.r.kinetic_law())
+
+        # Check bad kinetic law
+        expr = '2 * s'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.r.set_kinetic_law, expr)
+
+        # Check good kinetic law
+        expr = myokit.Multiply(myokit.Number(2), myokit.Name('s'))
+        self.r.set_kinetic_law(expr)
+
+        self.assertEqual(self.r.kinetic_law(), expr)
+
+    def test_modifiers(self):
+
+        # Check bad species
+        sid = 'modifier'
+        species = 'species'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.r.add_modifier, species, sid)
+
+        # Check invalid sid
+        sid = ';'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Invalid SId "', self.r.add_modifier, species, sid)
+
+        # Check good sid
+        sid = 'modifier'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.r.add_modifier(species, sid)
+
+        self.assertEqual(len(self.r.modifiers()), 1)
+        self.assertIsInstance(
+            self.r.modifiers()[0], sbml.ModifierSpeciesReference)
+
+        # Check duplicate sid
+        sid = 'modifier'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Duplicate SId "', self.r.add_modifier, species,
+            sid)
+
+    def test_products(self):
+
+        # Check bad species
+        sid = 'product'
+        species = 'species'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.r.add_product, species, sid)
+
+        # Check invalid sid
+        sid = ';'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Invalid SId "', self.r.add_product, species, sid)
+
+        # Check good sid
+        sid = 'product'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.r.add_product(species, sid)
+
+        self.assertEqual(len(self.r.products()), 1)
+        self.assertIsInstance(
+            self.r.products()[0], sbml.SpeciesReference)
+
+        # Check duplicate sid
+        sid = 'product'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Duplicate SId "', self.r.add_product, species,
+            sid)
+
+    def test_reactants(self):
+
+        # Check bad species
+        sid = 'reactant'
+        species = 'species'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.r.add_reactant, species, sid)
+
+        # Check invalid sid
+        sid = ';'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Invalid SId "', self.r.add_reactant, species, sid)
+
+        # Check good sid
+        sid = 'reactant'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.r.add_reactant(species, sid)
+
+        self.assertEqual(len(self.r.reactants()), 1)
+        self.assertIsInstance(
+            self.r.reactants()[0], sbml.SpeciesReference)
+
+        # Check duplicate sid
+        sid = 'reactant'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid='species',
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Duplicate SId "', self.r.add_reactant, species,
+            sid)
+
+    def test_sid(self):
+        self.assertEqual(self.r.sid(), self.sid)
+
+    def test_species(self):
+
+        # Add modifier species
+        sid = 'modifier_species'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid=sid,
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.r.add_modifier(species, sid)
+
+        # Check that species are accessible
+        self.assertIsInstance(self.r.species(sid), sbml.Species)
+
+        # Add product species
+        sid = 'product_species'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid=sid,
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.r.add_product(species, sid)
+
+        # Check that species are accessible
+        self.assertIsInstance(self.r.species(sid), sbml.Species)
+
+        # Add reactant species
+        sid = 'reactant_species'
+        compartment = sbml.Compartment(self.model, sid='compartment')
+        species = sbml.Species(
+            compartment=compartment,
+            sid=sid,
+            is_amount=False,
+            is_constant=False,
+            is_boundary=False)
+        self.r.add_reactant(species, sid)
+
+        # Check that species are accessible
+        self.assertIsInstance(self.r.species(sid), sbml.Species)
+
+    def test_string_representation(self):
+        self.assertEqual(str(self.r), '<Reaction ' + self.sid + '>')
+
+
+class TestSpecies(unittest.TestCase):
+    """
+    Unit tests for :class:`Species`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = sbml.Model(name='model')
+        cls.c = cls.model.add_compartment(sid='compartment')
+
+    def test_is_amount(self):
+
+        # Test is amount
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=True, is_constant=False,
+            is_boundary=False)
+
+        self.assertTrue(species.is_amount())
+
+        # Test is concentration
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        self.assertFalse(species.is_amount())
+
+        # Test bad amount
+        sid = 'species'
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Is_amount <', sbml.Species, self.c,
+            sid, 'No', False, False)
+
+    def test_is_boundary(self):
+
+        # Test is boundary
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=True)
+
+        self.assertTrue(species.is_boundary())
+
+        # Test is not boundary
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        self.assertFalse(species.is_boundary())
+
+        # Test bad boundary
+        sid = 'species'
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Is_boundary <', sbml.Species, self.c,
+            sid, False, False, 'No')
+
+    def test_compartment(self):
+
+        # Bad compartment
+        sid = 'species'
+        comp = 'compartment'
+
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', sbml.Species, comp,
+            sid, False, 'No', False)
+
+        # Test good compartment
+        sid = 'species'
+        comp = self.c
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=True,
+            is_boundary=False)
+
+        self.assertEqual(species.compartment(), self.c)
+
+    def test_is_constant(self):
+
+        # Test is constant
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=True,
+            is_boundary=False)
+
+        self.assertTrue(species.is_constant())
+
+        # Test is not constant
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        self.assertFalse(species.is_boundary())
+
+        # Test bad constant
+        sid = 'species'
+        self.assertRaisesRegex(
+            sbml.SBMLError, 'Is_constant <', sbml.Species, self.c,
+            sid, False, 'No', False)
+
+    def test_conversion_factor(self):
+
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        # Test default value
+        self.assertIsNone(species.conversion_factor())
+
+        # Bad conversion factor
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', species.set_conversion_factor, 10)
+
+        # Good model conversion factor
+        factor = sbml.Parameter(self.model, 'parameter')
+        self.model.set_conversion_factor(factor)
+
+        self.assertEqual(species.conversion_factor(), factor)
+
+        # Good species conversion factor
+        factor = sbml.Parameter(self.model, 'parameter 2')
+        species.set_conversion_factor(factor)
+
+        self.assertEqual(species.conversion_factor(), factor)
+
+    def test_correct_initial_value(self):
+
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        # Check default
+        self.assertTrue(species.correct_initial_value())
+
+        # Check bad input
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', species.set_correct_initial_value, 'Yes')
+
+        # Check not correct units
+        species.set_correct_initial_value(False)
+        self.assertFalse(species.correct_initial_value())
+
+        # Check correct units
+        species.set_correct_initial_value(True)
+        self.assertTrue(species.correct_initial_value())
+
+    def test_initial_value(self):
+
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        # Check default initial value
+        self.assertIsNone(species.initial_value())
+
+        # Check bad value
+        expr = 2
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', species.set_initial_value, expr)
+
+        # Check good value
+        expr = myokit.Number(2)
+        species.set_initial_value(expr)
+
+        self.assertEqual(species.initial_value(), expr)
+
+    def test_is_rate(self):
+
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        # Check default
+        self.assertFalse(species.is_rate())
+
+        # Check setting rate to true
+        expr = myokit.Number(2)
+        species.set_value(value=expr, is_rate=True)
+
+        self.assertTrue(species.is_rate())
+
+    def test_sid(self):
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        self.assertEqual(species.sid(), sid)
+
+    def test_string_representation(self):
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        self.assertEqual(str(species), '<Species ' + sid + '>')
+
+    def test_substance_units(self):
+
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        # Check default substance units
+        unit = myokit.units.dimensionless
+        self.assertEqual(species.substance_units(), unit)
+
+        # Check bad units
+        unit = 'mg'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', species.set_substance_units, unit)
+
+        # Check model substance units
+        unit = myokit.units.g
+        self.model.set_substance_units(unit)
+
+        self.assertEqual(species.substance_units(), unit)
+
+        # Check species subtance units
+        unit = myokit.units.g * 1E-3
+        species.set_substance_units(unit)
+
+        self.assertEqual(species.substance_units(), unit)
+
+    def test_value(self):
+
+        sid = 'species'
+        species = sbml.Species(
+            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
+            is_boundary=False)
+
+        # Check bad value
+        expr = 2
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', species.set_value, expr)
+
+        # Check good value
+        expr = myokit.Number(2)
+        species.set_value(expr)
+
+        self.assertEqual(species.value(), expr)
+
+
+class TestSpeciesReference(unittest.TestCase):
+    """
+    Unit tests for :class:`SpeciesReference`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        model = sbml.Model(name='model')
+        comp = model.add_compartment(sid='compartment')
+        cls.species = sbml.Species(comp, 'species', False, False, False)
+        cls.sid = 'species_reference'
+        cls.sr = sbml.SpeciesReference(cls.species, cls.sid)
+
+    def test_initial_value(self):
+
+        # Check default initial value
+        self.assertIsNone(self.sr.initial_value())
+
+        # Check bad value
+        expr = 2
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.sr.set_initial_value, expr)
+
+        # Check good value
+        expr = myokit.Number(2)
+        self.sr.set_initial_value(expr)
+
+        self.assertEqual(self.sr.initial_value(), expr)
+
+    def test_is_rate(self):
+
+        # Check default
+        self.assertFalse(self.sr.is_rate())
+
+        # Check setting rate to true
+        expr = myokit.Number(2)
+        self.sr.set_value(value=expr, is_rate=True)
+
+        self.assertTrue(self.sr.is_rate())
+
+    def test_sid(self):
+        self.assertEqual(self.sr.sid(), self.sid)
+
+    def test_species(self):
+
+        # Check bad species
+        species = 'species'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', sbml.SpeciesReference, species)
+
+        # Check good species
+        self.assertEqual(self.sr.species(), self.species)
+
+    def test_value(self):
+
+        # Check bad value
+        expr = 2
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', self.sr.set_value, expr)
+
+        # Check good value
+        expr = myokit.Number(2)
+        self.sr.set_value(expr)
+
+        self.assertEqual(self.sr.value(), expr)
+
+
+class TestModifierSpeciesReference(unittest.TestCase):
+    """
+    Unit tests for :class:`ModifierSpeciesReference`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        model = sbml.Model(name='model')
+        comp = model.add_compartment(sid='compartment')
+        cls.species = sbml.Species(comp, 'species', False, False, False)
+        cls.sid = 'modifier_species_reference'
+        cls.sr = sbml.ModifierSpeciesReference(cls.species, cls.sid)
+
+    def test_sid(self):
+        self.assertEqual(self.sr.sid(), self.sid)
+
+    def test_species(self):
+
+        # Check bad species
+        species = 'species'
+        self.assertRaisesRegex(
+            sbml.SBMLError, '<', sbml.ModifierSpeciesReference, species)
+
+        # Check good species
+        self.assertEqual(self.sr.species(), self.species)
+
+
 class SBMLTestMyokitModel(unittest.TestCase):
     """
     Unit tests for Model.myokit_model method.
@@ -510,8 +1163,6 @@ class SBMLTestMyokitModel(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.p = SBMLParser()
-
-        #
 
     def parse(self, xml, lvl=3, v=2):
         """
@@ -838,17 +1489,11 @@ class SBMLTestMyokitModel(unittest.TestCase):
     def test_species_exist(self):
         # Tests whether species initialisation in amount and concentration
         # works.
-        a = ('<model>'
-             ' <listOfCompartments>'
-             '  <compartment id="c" />'
-             ' </listOfCompartments>'
-             ' <listOfSpecies>')
-        b = (' </listOfSpecies>'
-             '</model>')
 
         # Species in amount
-        x = '<species compartment="c" id="spec" hasOnlySubstanceUnits="true"/>'
-        m = self.parse(a + x + b)
+        m = sbml.Model()
+        c = m.add_compartment('c')
+        s = m.add_species(c, 'spec', is_amount=True)
         m = m.myokit_model()
 
         # Check whether species exists in amount
@@ -860,8 +1505,9 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertEqual(component.count_variables(), 2)
 
         # Species in concentration
-        x = '<species compartment="c" id="spec" />'
-        m = self.parse(a + x + b)
+        m = sbml.Model()
+        c = m.add_compartment('c')
+        s = m.add_species(c, 'spec', is_amount=False)
         m = m.myokit_model()
 
         # Check whether species exists in amount and concentration
@@ -1704,659 +2350,6 @@ class SBMLTestMyokitModel(unittest.TestCase):
 
         # Chet that variable is time bound
         self.assertTrue(var.binding(), 'time')
-
-
-class TestParameter(unittest.TestCase):
-    """
-    Unit tests for :class:`Parameter`.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.model = sbml.Model(name='model')
-        cls.sid = 'parameter'
-        cls.p = cls.model.add_parameter(sid=cls.sid)
-
-    def test_bad_model(self):
-
-        model = 'model'
-        sid = 'parameter'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', sbml.Parameter, model, sid)
-
-    def test_initial_value(self):
-
-        # Check default initial value
-        self.assertIsNone(self.p.initial_value())
-
-        # Check bad value
-        expr = 2
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.p.set_initial_value, expr)
-
-        # Check good value
-        expr = myokit.Number(2)
-        self.p.set_initial_value(expr)
-
-        self.assertEqual(self.p.initial_value(), expr)
-
-    def test_is_rate(self):
-
-        # Check default
-        self.assertFalse(self.p.is_rate())
-
-        # Check setting rate to true
-        expr = myokit.Number(2)
-        self.p.set_value(value=expr, is_rate=True)
-
-        self.assertTrue(self.p.is_rate())
-
-    def test_sid(self):
-        self.assertEqual(self.p.sid(), self.sid)
-
-    def test_string_representation(self):
-        self.assertEqual(str(self.p), '<Parameter ' + self.sid + '>')
-
-    def test_units(self):
-
-        # Check default units
-        self.assertIsNone(self.p.units())
-
-        # Check bad size units
-        unit = 'mL'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.p.set_units, unit)
-
-        # Check valid size units
-        unit = myokit.units.L * 1E-3
-        self.p.set_units(unit)
-
-        self.assertEqual(self.p.units(), unit)
-
-    def test_value(self):
-
-        # Check bad value
-        expr = 2
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.p.set_value, expr)
-
-        # Check good value
-        expr = myokit.Number(2)
-        self.p.set_value(expr)
-
-        self.assertEqual(self.p.value(), expr)
-
-
-class TestReaction(unittest.TestCase):
-    """
-    Unit tests for :class:`Reaction`.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.model = sbml.Model(name='model')
-        cls.sid = 'reaction'
-        cls.r = cls.model.add_reaction(sid=cls.sid)
-
-    def test_bad_model(self):
-
-        model = 'model'
-        sid = 'reaction'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', sbml.Reaction, model, sid)
-
-    def test_kinetic_law(self):
-
-        # Check default
-        self.assertIsNone(self.r.kinetic_law())
-
-        # Check bad kinetic law
-        expr = '2 * s'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.r.set_kinetic_law, expr)
-
-        # Check good kinetic law
-        expr = myokit.Multiply(myokit.Number(2), myokit.Name('s'))
-        self.r.set_kinetic_law(expr)
-
-        self.assertEqual(self.r.kinetic_law(), expr)
-
-    def test_modifiers(self):
-
-        # Check bad species
-        sid = 'modifier'
-        species = 'species'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.r.add_modifier, species, sid)
-
-        # Check invalid sid
-        sid = ';'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Invalid SId "', self.r.add_modifier, species, sid)
-
-        # Check good sid
-        sid = 'modifier'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.r.add_modifier(species, sid)
-
-        self.assertEqual(len(self.r.modifiers()), 1)
-        self.assertIsInstance(
-            self.r.modifiers()[0], sbml.ModifierSpeciesReference)
-
-        # Check duplicate sid
-        sid = 'modifier'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Duplicate SId "', self.r.add_modifier, species,
-            sid)
-
-    def test_products(self):
-
-        # Check bad species
-        sid = 'product'
-        species = 'species'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.r.add_product, species, sid)
-
-        # Check invalid sid
-        sid = ';'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Invalid SId "', self.r.add_product, species, sid)
-
-        # Check good sid
-        sid = 'product'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.r.add_product(species, sid)
-
-        self.assertEqual(len(self.r.products()), 1)
-        self.assertIsInstance(
-            self.r.products()[0], sbml.SpeciesReference)
-
-        # Check duplicate sid
-        sid = 'product'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Duplicate SId "', self.r.add_product, species,
-            sid)
-
-    def test_reactants(self):
-
-        # Check bad species
-        sid = 'reactant'
-        species = 'species'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.r.add_reactant, species, sid)
-
-        # Check invalid sid
-        sid = ';'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Invalid SId "', self.r.add_reactant, species, sid)
-
-        # Check good sid
-        sid = 'reactant'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.r.add_reactant(species, sid)
-
-        self.assertEqual(len(self.r.reactants()), 1)
-        self.assertIsInstance(
-            self.r.reactants()[0], sbml.SpeciesReference)
-
-        # Check duplicate sid
-        sid = 'reactant'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid='species',
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Duplicate SId "', self.r.add_reactant, species,
-            sid)
-
-    def test_sid(self):
-        self.assertEqual(self.r.sid(), self.sid)
-
-    def test_species(self):
-
-        # Add modifier species
-        sid = 'modifier_species'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid=sid,
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.r.add_modifier(species, sid)
-
-        # Check that species are accessible
-        self.assertIsInstance(self.r.species(sid), sbml.Species)
-
-        # Add product species
-        sid = 'product_species'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid=sid,
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.r.add_product(species, sid)
-
-        # Check that species are accessible
-        self.assertIsInstance(self.r.species(sid), sbml.Species)
-
-        # Add reactant species
-        sid = 'reactant_species'
-        compartment = sbml.Compartment(self.model, sid='compartment')
-        species = sbml.Species(
-            compartment=compartment,
-            sid=sid,
-            is_amount=False,
-            is_constant=False,
-            is_boundary=False)
-        self.r.add_reactant(species, sid)
-
-        # Check that species are accessible
-        self.assertIsInstance(self.r.species(sid), sbml.Species)
-
-    def test_string_representation(self):
-        self.assertEqual(str(self.r), '<Reaction ' + self.sid + '>')
-
-
-class TestSpecies(unittest.TestCase):
-    """
-    Unit tests for :class:`Species`.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.model = sbml.Model(name='model')
-        cls.c = cls.model.add_compartment(sid='compartment')
-
-    def test_is_amount(self):
-
-        # Test is amount
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=True, is_constant=False,
-            is_boundary=False)
-
-        self.assertTrue(species.is_amount())
-
-        # Test is concentration
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        self.assertFalse(species.is_amount())
-
-        # Test bad amount
-        sid = 'species'
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Is_amount <', sbml.Species, self.c,
-            sid, 'No', False, False)
-
-    def test_is_boundary(self):
-
-        # Test is boundary
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=True)
-
-        self.assertTrue(species.is_boundary())
-
-        # Test is not boundary
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        self.assertFalse(species.is_boundary())
-
-        # Test bad boundary
-        sid = 'species'
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Is_boundary <', sbml.Species, self.c,
-            sid, False, False, 'No')
-
-    def test_compartment(self):
-
-        # Bad compartment
-        sid = 'species'
-        comp = 'compartment'
-
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', sbml.Species, comp,
-            sid, False, 'No', False)
-
-        # Test good compartment
-        sid = 'species'
-        comp = self.c
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=True,
-            is_boundary=False)
-
-        self.assertEqual(species.compartment(), self.c)
-
-    def test_is_constant(self):
-
-        # Test is constant
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=True,
-            is_boundary=False)
-
-        self.assertTrue(species.is_constant())
-
-        # Test is not constant
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        self.assertFalse(species.is_boundary())
-
-        # Test bad constant
-        sid = 'species'
-        self.assertRaisesRegex(
-            sbml.SBMLError, 'Is_constant <', sbml.Species, self.c,
-            sid, False, 'No', False)
-
-    def test_conversion_factor(self):
-
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        # Test default value
-        self.assertIsNone(species.conversion_factor())
-
-        # Bad conversion factor
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', species.set_conversion_factor, 10)
-
-        # Good model conversion factor
-        factor = sbml.Parameter(self.model, 'parameter')
-        self.model.set_conversion_factor(factor)
-
-        self.assertEqual(species.conversion_factor(), factor)
-
-        # Good species conversion factor
-        factor = sbml.Parameter(self.model, 'parameter 2')
-        species.set_conversion_factor(factor)
-
-        self.assertEqual(species.conversion_factor(), factor)
-
-    def test_correct_initial_value(self):
-
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        # Check default
-        self.assertTrue(species.correct_initial_value())
-
-        # Check bad input
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', species.set_correct_initial_value, 'Yes')
-
-        # Check not correct units
-        species.set_correct_initial_value(False)
-        self.assertFalse(species.correct_initial_value())
-
-        # Check correct units
-        species.set_correct_initial_value(True)
-        self.assertTrue(species.correct_initial_value())
-
-    def test_initial_value(self):
-
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        # Check default initial value
-        self.assertIsNone(species.initial_value())
-
-        # Check bad value
-        expr = 2
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', species.set_initial_value, expr)
-
-        # Check good value
-        expr = myokit.Number(2)
-        species.set_initial_value(expr)
-
-        self.assertEqual(species.initial_value(), expr)
-
-    def test_is_rate(self):
-
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        # Check default
-        self.assertFalse(species.is_rate())
-
-        # Check setting rate to true
-        expr = myokit.Number(2)
-        species.set_value(value=expr, is_rate=True)
-
-        self.assertTrue(species.is_rate())
-
-    def test_sid(self):
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        self.assertEqual(species.sid(), sid)
-
-    def test_string_representation(self):
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        self.assertEqual(str(species), '<Species ' + sid + '>')
-
-    def test_substance_units(self):
-
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        # Check default substance units
-        unit = myokit.units.dimensionless
-        self.assertEqual(species.substance_units(), unit)
-
-        # Check bad units
-        unit = 'mg'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', species.set_substance_units, unit)
-
-        # Check model substance units
-        unit = myokit.units.g
-        self.model.set_substance_units(unit)
-
-        self.assertEqual(species.substance_units(), unit)
-
-        # Check species subtance units
-        unit = myokit.units.g * 1E-3
-        species.set_substance_units(unit)
-
-        self.assertEqual(species.substance_units(), unit)
-
-    def test_value(self):
-
-        sid = 'species'
-        species = sbml.Species(
-            compartment=self.c, sid=sid, is_amount=False, is_constant=False,
-            is_boundary=False)
-
-        # Check bad value
-        expr = 2
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', species.set_value, expr)
-
-        # Check good value
-        expr = myokit.Number(2)
-        species.set_value(expr)
-
-        self.assertEqual(species.value(), expr)
-
-
-class TestSpeciesReference(unittest.TestCase):
-    """
-    Unit tests for :class:`SpeciesReference`.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        model = sbml.Model(name='model')
-        comp = model.add_compartment(sid='compartment')
-        cls.species = sbml.Species(comp, 'species', False, False, False)
-        cls.sid = 'species_reference'
-        cls.sr = sbml.SpeciesReference(cls.species, cls.sid)
-
-    def test_initial_value(self):
-
-        # Check default initial value
-        self.assertIsNone(self.sr.initial_value())
-
-        # Check bad value
-        expr = 2
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.sr.set_initial_value, expr)
-
-        # Check good value
-        expr = myokit.Number(2)
-        self.sr.set_initial_value(expr)
-
-        self.assertEqual(self.sr.initial_value(), expr)
-
-    def test_is_rate(self):
-
-        # Check default
-        self.assertFalse(self.sr.is_rate())
-
-        # Check setting rate to true
-        expr = myokit.Number(2)
-        self.sr.set_value(value=expr, is_rate=True)
-
-        self.assertTrue(self.sr.is_rate())
-
-    def test_sid(self):
-        self.assertEqual(self.sr.sid(), self.sid)
-
-    def test_species(self):
-
-        # Check bad species
-        species = 'species'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', sbml.SpeciesReference, species)
-
-        # Check good species
-        self.assertEqual(self.sr.species(), self.species)
-
-    def test_value(self):
-
-        # Check bad value
-        expr = 2
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', self.sr.set_value, expr)
-
-        # Check good value
-        expr = myokit.Number(2)
-        self.sr.set_value(expr)
-
-        self.assertEqual(self.sr.value(), expr)
-
-
-class TestModifierSpeciesReference(unittest.TestCase):
-    """
-    Unit tests for :class:`ModifierSpeciesReference`.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        model = sbml.Model(name='model')
-        comp = model.add_compartment(sid='compartment')
-        cls.species = sbml.Species(comp, 'species', False, False, False)
-        cls.sid = 'modifier_species_reference'
-        cls.sr = sbml.ModifierSpeciesReference(cls.species, cls.sid)
-
-    def test_sid(self):
-        self.assertEqual(self.sr.sid(), self.sid)
-
-    def test_species(self):
-
-        # Check bad species
-        species = 'species'
-        self.assertRaisesRegex(
-            sbml.SBMLError, '<', sbml.ModifierSpeciesReference, species)
-
-        # Check good species
-        self.assertEqual(self.sr.species(), self.species)
 
 
 if __name__ == '__main__':

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1157,31 +1157,6 @@ class SBMLTestMyokitModel(unittest.TestCase):
     Unit tests for Model.myokit_model method.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.p = SBMLParser()
-
-    def parse(self, xml, lvl=3, v=2):
-        """
-        Inserts the given ``xml`` into an <sbml> element, parses it, and
-        returns the result.
-        """
-        return self.p.parse_string(self.wrap(xml, lvl, v))
-
-    def wrap(self, xml_content, level=3, version=2):
-        """
-        Wraps ``xml_content`` into an SBML document of the specified ``level``
-        and ``version``.
-        """
-        lv = 'level' + str(level) + '/version' + str(version)
-        return (
-            '<sbml xmlns="http://www.sbml.org/sbml/' + lv + '/core"'
-            ' level="' + str(level) + '"'
-            ' version="' + str(version) + '">'
-            + xml_content +
-            '</sbml>'
-        )
-
     def test_compartments(self):
         # Tests whether compartments are added properly to the myokit model.
 

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1373,7 +1373,8 @@ class SBMLTestMyokitModel(unittest.TestCase):
         mm = m.myokit_model()
         sc = mm.get('comp.spec_2_concentration')
         self.assertFalse(sc.is_state())
-        self.assertEqual(sc.rhs(), myokit.Number(4))
+        self.assertEqual(
+            sc.rhs().code(), 'comp.spec_2_amount / comp.size')
         sa = mm.get('comp.spec_2_amount')
         self.assertFalse(sa.is_state())
         self.assertEqual(sa.rhs().code(), '4 * comp.size')
@@ -1397,7 +1398,8 @@ class SBMLTestMyokitModel(unittest.TestCase):
         mm = m.myokit_model()
         sc = mm.get('comp.spec_2_concentration')
         self.assertFalse(sc.is_state())
-        self.assertEqual(sc.rhs(), myokit.Number(4))
+        self.assertEqual(
+            sc.rhs().code(), 'comp.spec_2_amount / comp.size')
         sa = mm.get('comp.spec_2_amount')
         self.assertFalse(sa.is_state())
         self.assertEqual(sa.rhs().code(), '4 * comp.size')
@@ -1427,12 +1429,13 @@ class SBMLTestMyokitModel(unittest.TestCase):
         s2.set_value(myokit.Number(4), is_rate=True)
         mm = m.myokit_model()
         sc = mm.get('comp.spec_2_concentration')
-        self.assertTrue(sc.is_state())
-        self.assertEqual(sc.rhs(), myokit.Number(4))
-        self.assertEqual(sc.state_value(), 0)
+        self.assertFalse(sc.is_state())
+        self.assertEqual(
+            sc.rhs().code(), 'comp.spec_2_amount / comp.size')
         sa = mm.get('comp.spec_2_amount')
-        self.assertFalse(sa.is_state())
+        self.assertTrue(sa.is_state())
         self.assertEqual(sa.rhs().code(), '4 * comp.size')
+        self.assertEqual(sa.state_value(), 0)
 
     def test_add_species(self):
         # Tests whether species are added properly to the associated

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1408,7 +1408,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         ms = mm.get('comp.spec_1_amount')
         self.assertTrue(ms.is_state())
         self.assertEqual(ms.rhs(), myokit.Number(3))
-        self.assertEqual(ms.state_value(), 0)
+        self.assertEqual(ms.state_value(), 7)
 
         # Species in concentration
         s2 = m.add_species(c, 'spec_2', is_amount=False)
@@ -1441,7 +1441,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         ms = mm.get('comp.spec_1_amount')
         self.assertTrue(ms.is_state())
         self.assertEqual(ms.rhs(), myokit.Number(3))
-        self.assertEqual(ms.state_value(), 7 * 2)
+        self.assertEqual(ms.state_value(), 7)
 
         # Species in concentration
         s2 = m.add_species(c, 'spec_2', is_amount=False)
@@ -1590,7 +1590,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         s2 = m.add_species(compartment=c, sid='s2', is_boundary=True)
         s2.set_initial_value(myokit.Number(2), in_amount=True)
         s3 = m.add_species(compartment=c, sid='s3', is_boundary=True)
-        s3.set_initial_value(myokit.Number(1.5))
+        s3.set_initial_value(myokit.Number(1.5), in_amount=False)
         r = m.add_reaction('r')
         r.add_reactant(s1)
         r.add_reactant(s2)
@@ -1610,6 +1610,8 @@ class SBMLTestMyokitModel(unittest.TestCase):
 
         # Check rhs
         var = mm.get('c.s1_amount')
+        self.assertEqual(
+            var.rhs().code(), '-(c.s1_concentration + c.s3_concentration)')
         self.assertEqual(var.eval(), -(2 / 1.2 + 1.5))
 
         var = mm.get('c.s2_amount')
@@ -1794,8 +1796,8 @@ class SBMLTestMyokitModel(unittest.TestCase):
         sr1.set_value(myokit.Plus(myokit.Name(p), myokit.Number(5)))
         sr2 = r.add_product(s2, 'sr2')
         sr2.set_initial_value(myokit.Number(3.5))
-        sr1.set_value(
-            myokit.Plus(myokit.Name(p), myokit.Number(1)), True)
+        sr2.set_value(
+            myokit.Minus(myokit.Name(p), myokit.Number(1)), True)
         r.set_kinetic_law(myokit.Plus(myokit.Name(s1), myokit.Name(s2)))
         mm = m.myokit_model()
 

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1763,214 +1763,80 @@ class SBMLTestMyokitModel(unittest.TestCase):
     def test_reaction_stoichiometries_exist(self):
         # Tests whether stoichiometries are created properly.
 
-        a = ('<model>'
-             ' <listOfCompartments>'
-             '  <compartment id="c" size="1.2" />'
-             ' </listOfCompartments>'
-             ' <listOfSpecies>'
-             '  <species id="s1" compartment="c" />'
-             '  <species id="s2" compartment="c" />'
-             ' </listOfSpecies>'
-             ' <listOfReactions>'
-             '  <reaction id="r">'
-             '   <listOfReactants>'
-             '    <speciesReference species="s1" id="sr" />'
-             '   </listOfReactants>'
-             '   <listOfProducts>'
-             '    <speciesReference species="s2" id="sp" />'
-             '   </listOfProducts>'
-             '   <kineticLaw>'
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <apply>'
-             '      <plus/>'
-             '      <ci>s1</ci>'
-             '      <ci>s2</ci>'
-             '     </apply>'
-             '    </math>'
-             '   </kineticLaw>'
-             '  </reaction>'
-             ' </listOfReactions>')
-        b = ('</model>')
-
-        m = self.parse(a + b)
-        m = m.myokit_model()
+        m = sbml.Model()
+        c = m.add_compartment('c')
+        c.set_initial_value(myokit.Number(1.2))
+        s1 = m.add_species(c, 's1')
+        s1.set_initial_value(myokit.Number(2), in_amount=True)
+        s2 = m.add_species(c, 's2')
+        s2.set_initial_value(myokit.Number(1.5))
+        r = m.add_reaction('r')
+        r.add_reactant(s1, 'sr1')
+        r.add_product(s2, 'sr2')
+        r.set_kinetic_law(myokit.Plus(myokit.Name(s1), myokit.Name(s2)))
+        mm = m.myokit_model()
 
         # Check that stoichiometry variables exists
-        self.assertTrue(m.has_variable('c.sr'))
-        self.assertTrue(m.has_variable('c.sp'))
+        self.assertTrue(mm.has_variable('c.sr1'))
+        self.assertTrue(mm.has_variable('c.sr2'))
 
     def test_reaction_stoichiometries_initial_value(self):
         # Tests whether initial values of stoichiometries are set properly.
 
-        a = ('<model>'
-             ' <listOfCompartments>'
-             '  <compartment id="c" size="1.2" />'
-             ' </listOfCompartments>'
-             ' <listOfSpecies>'
-             '  <species id="s1" compartment="c" />'
-             '  <species id="s2" compartment="c" />'
-             ' </listOfSpecies>'
-             ' <listOfReactions>'
-             '  <reaction id="r">'
-             '   <listOfReactants>'
-             '    <speciesReference species="s1" id="sr" stoichiometry="2.1"/>'
-             '   </listOfReactants>'
-             '   <listOfProducts>'
-             '    <speciesReference species="s2" id="sp" stoichiometry="3.5"/>'
-             '   </listOfProducts>'
-             '   <kineticLaw>'
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <apply>'
-             '      <plus/>'
-             '      <ci>s1</ci>'
-             '      <ci>s2</ci>'
-             '     </apply>'
-             '    </math>'
-             '   </kineticLaw>'
-             '  </reaction>'
-             ' </listOfReactions>')
-        b = ('</model>')
-
-        # Test I: Set by speciesReference
-        m = self.parse(a + b)
-        m = m.myokit_model()
+        m = sbml.Model()
+        c = m.add_compartment('c')
+        c.set_initial_value(myokit.Number(1.2))
+        s1 = m.add_species(c, 's1')
+        s2 = m.add_species(c, 's2')
+        r = m.add_reaction('r')
+        sr1 = r.add_reactant(s1, 'sr1')
+        sr1.set_initial_value(myokit.Number(2.1))
+        sr2 = r.add_product(s2, 'sr2')
+        sr2.set_initial_value(myokit.Number(3.5))
+        r.set_kinetic_law(myokit.Plus(myokit.Name(s1), myokit.Name(s2)))
+        mm = m.myokit_model()
 
         # Check that initial values are set properly
-        stoich_reactant = m.get('c.sr')
-        stoich_product = m.get('c.sp')
+        stoich_reactant = mm.get('c.sr1')
+        stoich_product = mm.get('c.sr2')
 
         self.assertEqual(stoich_reactant.eval(), 2.1)
         self.assertEqual(stoich_product.eval(), 3.5)
 
-        # Test I: Set by initialAssignment
-        x = (' <listOfInitialAssignments>'
-             '  <initialAssignment symbol="sr">'
-             '   <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <cn>4.51</cn>'
-             '   </math>'
-             '  </initialAssignment>'
-             '  <initialAssignment symbol="sp">'
-             '   <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <cn>6</cn>'
-             '   </math>'
-             '  </initialAssignment>'
-             ' </listOfInitialAssignments>')
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that initial values are set properly
-        stoich_reactant = m.get('c.sr')
-        stoich_product = m.get('c.sp')
-
-        self.assertEqual(stoich_reactant.eval(), 4.51)
-        self.assertEqual(stoich_product.eval(), 6)
-
     def test_reaction_stoichiometry_values(self):
         # Tests whether values of parameters are set correctly.
 
-        a = ('<model>'
-             ' <listOfCompartments>'
-             '  <compartment id="c" size="1.2" />'
-             ' </listOfCompartments>'
-             ' <listOfParameters>'
-             '  <parameter id="V" value="10.23">'
-             '  </parameter>'
-             ' </listOfParameters>'
-             ' <listOfSpecies>'
-             '  <species id="s1" compartment="c" />'
-             '  <species id="s2" compartment="c" />'
-             ' </listOfSpecies>'
-             ' <listOfReactions>'
-             '  <reaction id="r">'
-             '   <listOfReactants>'
-             '    <speciesReference species="s1" id="sr" stoichiometry="2.1"/>'
-             '   </listOfReactants>'
-             '   <listOfProducts>'
-             '    <speciesReference species="s2" id="sp" stoichiometry="3.5"/>'
-             '   </listOfProducts>'
-             '   <kineticLaw>'
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '     <apply>'
-             '      <plus/>'
-             '      <ci>s1</ci>'
-             '      <ci>s2</ci>'
-             '     </apply>'
-             '    </math>'
-             '   </kineticLaw>'
-             '  </reaction>'
-             ' </listOfReactions>')
-        b = ('</model>')
+        m = sbml.Model()
+        p = m.add_parameter('V')
+        p.set_value(myokit.Number(10.23))
+        c = m.add_compartment('c')
+        c.set_initial_value(myokit.Number(1.2))
+        s1 = m.add_species(c, 's1')
+        s2 = m.add_species(c, 's2')
+        r = m.add_reaction('r')
+        sr1 = r.add_reactant(s1, 'sr1')
+        sr1.set_initial_value(myokit.Number(2.1))
+        sr1.set_value(myokit.Plus(myokit.Name(p), myokit.Number(5)))
+        sr2 = r.add_product(s2, 'sr2')
+        sr2.set_initial_value(myokit.Number(3.5))
+        sr1.set_value(
+            myokit.Plus(myokit.Name(p), myokit.Number(1)), True)
+        r.set_kinetic_law(myokit.Plus(myokit.Name(s1), myokit.Name(s2)))
+        mm = m.myokit_model()
 
-        # Test I: Set by assignmentRule
-        x = ('<listOfRules>'
-             '  <assignmentRule variable="sr"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <plus/>'
-             '        <ci> V </ci>'
-             '        <cn> 5 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </assignmentRule>'
-             '  <assignmentRule variable="sp"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <plus/>'
-             '        <ci> V </ci>'
-             '        <cn> 3.81 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </assignmentRule>'
-             '</listOfRules>')
+        # Check that stoichiometries are state/ not state variables
+        var = mm.get('c.sr1')
+        self.assertFalse(var.is_state())
 
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
+        var = mm.get('c.sr2')
+        self.assertTrue(var.is_state())
 
         # Check value of stoichiometries
-        var = m.get('c.sr')
+        var = mm.get('c.sr1')
         self.assertEqual(var.eval(), 15.23)
 
-        var = m.get('c.sp')
-        self.assertAlmostEqual(var.eval(), 14.04)
-
-        # Test II: Set by rateRule
-        x = ('<listOfRules>'
-             '  <rateRule variable="sr"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <plus/>'
-             '        <ci> V </ci>'
-             '        <cn> 3 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </rateRule>'
-             '  <rateRule variable="sp"> '
-             '    <math xmlns="http://www.w3.org/1998/Math/MathML">'
-             '      <apply>'
-             '        <minus/>'
-             '        <ci> V </ci>'
-             '        <cn> 1 </cn>'
-             '      </apply>'
-             '    </math>'
-             '  </rateRule>'
-             '</listOfRules>')
-
-        m = self.parse(a + x + b)
-        m = m.myokit_model()
-
-        # Check that stoichiometries are state variables
-        var = m.get('c.sr')
-        self.assertTrue(var.is_state())
-
-        var = m.get('c.sp')
-        self.assertTrue(var.is_state())
-
-        # Check value of stoichiometries
-        var = m.get('c.sr')
-        self.assertEqual(var.eval(), 13.23)
-
-        var = m.get('c.sp')
+        var = mm.get('c.sr2')
+        self.assertEqual(var.state_value(), 3.5)
         self.assertEqual(var.eval(), 9.23)
 
     def test_reaction_stoichiometries(self):

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -972,6 +972,13 @@ class TestSpecies(unittest.TestCase):
         self.assertEqual(value, expr)
         self.assertTrue(is_amount)
 
+        # Check bad in_amount argument
+        expr = myokit.Number(10.1)
+        self.assertRaisesRegex(
+            sbml.SBMLError,
+            '<in_amount> needs to be an instance of bool or None.',
+            species.set_initial_value, expr, 'Yes')
+
     def test_is_rate(self):
 
         sid = 'species'

--- a/myokit/tests/test_sbml_parser.py
+++ b/myokit/tests/test_sbml_parser.py
@@ -465,7 +465,9 @@ class TestSBMLParser(unittest.TestCase):
         d = ('</model>')
         m = self.parse(a + b + c + d)
         s = m.species('s')
-        self.assertEqual(s.initial_value(), myokit.Number(4.5))
+        expr, expr_in_amount = s.initial_value()
+        self.assertEqual(expr, myokit.Number(4.5))
+        self.assertIsNone(expr_in_amount)
 
         # Reset a species amount (or concentration)
         b = (' <listOfSpecies>'
@@ -473,10 +475,14 @@ class TestSBMLParser(unittest.TestCase):
              ' </listOfSpecies>')
         m = self.parse(a + b + d)
         s = m.species('s')
-        self.assertEqual(s.initial_value(), myokit.Number(3))
+        expr, expr_in_amount = s.initial_value()
+        self.assertEqual(expr, myokit.Number(3))
+        self.assertFalse(expr_in_amount)
         m = self.parse(a + b + c + d)
         s = m.species('s')
-        self.assertEqual(s.initial_value(), myokit.Number(4.5))
+        expr, expr_in_amount = s.initial_value()
+        self.assertEqual(expr, myokit.Number(4.5))
+        self.assertIsNone(expr_in_amount)
 
         # Set a stoichiometry
         a = ('<model>'
@@ -931,10 +937,14 @@ class TestSBMLParser(unittest.TestCase):
         b = ('</model>')
 
         p = self.parse(a + b).species('sx')
-        self.assertEqual(p.initial_value(), myokit.Number(3.4))
+        expr, expr_in_amount = p.initial_value()
+        self.assertEqual(expr, myokit.Number(3.4))
+        self.assertTrue(expr_in_amount)
 
         p = self.parse(a + b).species('sy')
-        self.assertEqual(p.initial_value(), myokit.Number(1.2))
+        expr, expr_in_amount = p.initial_value()
+        self.assertEqual(expr, myokit.Number(1.2))
+        self.assertFalse(expr_in_amount)
 
         # Set RHS with assignmentRule or rateRule
         x = ('<listOfRules>'
@@ -965,8 +975,13 @@ class TestSBMLParser(unittest.TestCase):
         px = self.parse(a + x + b).species('sx')
         py = self.parse(a + x + b).species('sy')
 
-        self.assertEqual(px.initial_value(), myokit.Number(3.4))
-        self.assertEqual(py.initial_value(), myokit.Number(1.2))
+        expr, expr_in_amount = px.initial_value()
+        self.assertEqual(expr, myokit.Number(3.4))
+        self.assertTrue(expr_in_amount)
+
+        expr, expr_in_amount = py.initial_value()
+        self.assertEqual(expr, myokit.Number(1.2))
+        self.assertFalse(expr_in_amount)
 
         self.assertFalse(px.is_rate())
         self.assertTrue(py.is_rate())
@@ -1205,13 +1220,17 @@ class TestSBMLParser(unittest.TestCase):
         x = ('<species compartment="c" id="s"'
              ' hasOnlySubstanceUnits="true" initialAmount="3" />')
         s = self.parse(a + x + b).species('s')
-        self.assertEqual(s.initial_value(), myokit.Number(3))
+        expr, expr_in_amount = s.initial_value()
+        self.assertEqual(expr, myokit.Number(3))
+        self.assertTrue(expr_in_amount)
 
         # Initial concentration
         x = ('<species compartment="c" id="s"'
              ' hasOnlySubstanceUnits="false" initialConcentration="1.2" />')
         s = self.parse(a + x + b).species('s')
-        self.assertEqual(s.initial_value(), myokit.Number(1.2))
+        expr, expr_in_amount = s.initial_value()
+        self.assertEqual(expr, myokit.Number(1.2))
+        self.assertFalse(expr_in_amount)
 
         # Set both initial amount and concentration
         x = ('<species compartment="c" id="s"'


### PR DESCRIPTION
- moved myokit_model tests to bottom of sbml api test file
- rewrote a few tests to avoid parser
- updated compartment size test to add missing tests for rate
  - in general, these tests shouldn't test private methods, just the public API!
  - seems that setting rates for sizes wasn't covered in the tests? new test fails