### PR TITLE
Model.pyfunc() now validates the model before running (and fails if t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This page lists the main changes made to Myokit in each release.
   - [#622](https://github.com/MichaelClerx/myokit/pull/622) `Model.format_state` and `Model.format_state_derivatives` now take a `precision` argument.
   - [#622](https://github.com/MichaelClerx/myokit/pull/622) If errors occur, the `SimulationOpenCL` now displays improved (and hopefully more informative) output.
   - [#623](https://github.com/MichaelClerx/myokit/pull/623) Updated licensing info.
+  - [#653](https://github.com/MichaelClerx/myokit/pull/653) `Model.pyfunc()` now validates the model before running (and fails if the model does not validate).
 - Deprecated
   - [#622](https://github.com/MichaelClerx/myokit/pull/622) `SimulationOpenCL.is2d()` was deprecated in favour of `SimulationOpenCL.is_2d()`.
   - [#632](https://github.com/MichaelClerx/myokit/pull/632) `DataBlock1d.from_DataLog` and `DataBlock2d.from_DataLog` have both been deprecated, in favour of new `from_log` methods.

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -3963,6 +3963,12 @@ class Variable(VarOwner):
         :class:`myokit.LhsExpression` objects in the same order as the function
         arguments.
         """
+        # Expression writer uses unames, so must have called validate() since
+        # last changes
+        model = self.model()
+        if not model.is_valid():
+            model.validate()
+
         # Get expression writer
         if use_numpy:
             import numpy
@@ -3972,7 +3978,7 @@ class Variable(VarOwner):
             w = myokit.python_writer()
 
         # Get arguments, equations
-        eqs, args = self.model().expressions_for(self)
+        eqs, args = model.expressions_for(self)
 
         # Handle function arguments
         func = [w.ex(x) for x in args]

--- a/myokit/tests/test_variable.py
+++ b/myokit/tests/test_variable.py
@@ -214,6 +214,12 @@ class VariableTest(unittest.TestCase):
         z = c.add_variable('z')
         z.set_rhs('3 * x + y')
 
+        # Invalid model: pyfunc fails
+        self.assertRaises(myokit.IntegrityError, z.pyfunc)
+        t = c.add_variable('time')
+        t.set_rhs(0)
+        t.set_binding('time')
+
         # No states --> No arguments
         f = z.pyfunc(use_numpy=False)
         self.assertEqual(f(), 13)


### PR DESCRIPTION
`Model.pyfunc()` now validates the model before running - and fails if the model does not validate.

This prevents issues with unames not being set, amongst other possible issues that can arise with inspection of cyclical variables etc.
