### PR TITLE
Add jump-to-variable function in IDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This page lists the main changes made to Myokit in each release.
   - [#672](https://github.com/MichaelClerx/myokit/pull/672) Now tested on Sundials 5 (locally).
   - [#672](https://github.com/MichaelClerx/myokit/pull/672) Now testing on Python 3.9.
   - [#672](https://github.com/MichaelClerx/myokit/pull/672) `Simulation.run` documentation is now more clear on what happens for very short simulation durations (or zero).
+  - [#673](https://github.com/MichaelClerx/myokit/pull/673) Added a method `Model.has_parse_info` that checks if the model contains information from parsing (i.e. line numbers).
+  - [#673](https://github.com/MichaelClerx/myokit/pull/673) Added a parameter `raw` to `Model.show_line_of` that returns the line number as an integer
 - Changed
 - Deprecated
 - Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This page lists the main changes made to Myokit in each release.
   - [#672](https://github.com/MichaelClerx/myokit/pull/672) `Simulation.run` documentation is now more clear on what happens for very short simulation durations (or zero).
   - [#673](https://github.com/MichaelClerx/myokit/pull/673) Added a method `Model.has_parse_info` that checks if the model contains information from parsing (i.e. line numbers).
   - [#673](https://github.com/MichaelClerx/myokit/pull/673) Added a parameter `raw` to `Model.show_line_of` that returns the line number as an integer
+  - [#673](https://github.com/MichaelClerx/myokit/pull/673) Added a method to the IDE that lets you jump to the definition of a selected variable.
 - Changed
 - Deprecated
 - Removed

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -1631,9 +1631,17 @@ class Model(ObjectWithMeta, VarProvider):
         remaining = equations['*remaining*']
         return len(remaining) > 0
 
+    def has_parse_info(self):
+        """
+        Returns ``True`` if this model retains parsing information, so that
+        methods such as :meth:`item_at_text_position` and :meth:`show_line_of`
+        can be used.
+        """
+        return bool(self._tokens)
+
     def has_warnings(self):
         """
-        Returns True if this model has any warnings.
+        Returns ``True`` if this model has any warnings.
         """
         return len(self._warnings)
 
@@ -2605,13 +2613,20 @@ class Model(ObjectWithMeta, VarProvider):
             ' future versions of Myokit. Please use `show_line_of` instead.')
         self.show_line_of(var)
 
-    def show_line_of(self, var):
+    def show_line_of(self, var, raw=False):
         """
         Returns a string containing the type of variable ``var`` is and the
         line it was defined on.
+
+        If ``raw`` is set to ``True`` the method returns an integer with the
+        line number, or ``None`` if no line number information is known (i.e.
+        if this model wasn't created by parsing).
         """
+        if raw:
+            return int(var._token[2]) if var._token is not None else None
+
         var, out = self._var_info(var)
-        if var._token:
+        if var._token is not None:
             out.append('Defined on line ' + str(var._token[2]))
         return '\n'.join(out)
 

--- a/myokit/gui/ide.py
+++ b/myokit/gui/ide.py
@@ -1079,6 +1079,30 @@ class MyokitIDE(myokit.gui.MyokitApplication):
         except Exception:
             self.show_exception()
 
+    def action_variable_definition(self):
+        """
+        Jump to the variable pointed at by the caret.
+        """
+        try:
+            if self._editor_tabs.currentWidget() != self._model_editor:
+                self._console.write(
+                    'Variable info can only be displayed for model variables.')
+                return
+            var = self.selected_variable()
+            if var is False:
+                return  # Model error
+            elif var is None:
+                self._console.write(
+                    'No variable selected. Please select a variable in the'
+                    ' model editing tab.')
+                return
+            # Jump! (you might as well)
+            line = var.model().show_line_of(var, raw=True)
+            self.statusBar().showMessage('Jumping to line ' + str(line) + '.')
+            self._model_editor.jump_to(line - 1, 0)
+        except Exception:
+            self.show_exception()
+
     def action_variable_dependencies(self):
         """
         Finds the variable pointed at by the cursor in the model editor and
@@ -1890,6 +1914,16 @@ class MyokitIDE(myokit.gui.MyokitApplication):
             'Display a graph of the selected variable.')
         self._tool_variable_graph.triggered.connect(self.action_variable_graph)
         self._menu_analysis.addAction(self._tool_variable_graph)
+        # Analysis > Jump to variable definition
+        self._tool_variable_jump = QtWidgets.QAction(
+            'Jump to variable definition', self)
+        self._tool_variable_jump.setShortcut('Ctrl+J')
+        self._tool_variable_jump.setStatusTip(
+            'Jump to the selected variable\'s definition.')
+        self._tool_variable_jump.triggered.connect(
+            self.action_variable_definition)
+        self._menu_analysis.addAction(self._tool_variable_jump)
+
         # Analysis > ----
         self._menu_analysis.addSeparator()
         # Analysis > Evaluate state derivatives

--- a/myokit/gui/source.py
+++ b/myokit/gui/source.py
@@ -196,7 +196,7 @@ class Editor(QtWidgets.QPlainTextEdit):
 
     def jump_to(self, line, char):
         """
-        Jumps to the given line and row.
+        Jumps to the given line and row (with indices starting at 0).
         """
         block = self.document().findBlockByNumber(line)
         cursor = self.textCursor()

--- a/myokit/tests/test_model.py
+++ b/myokit/tests/test_model.py
@@ -273,7 +273,7 @@ class ModelTest(unittest.TestCase):
         m.check_units(s)
 
     def test_clone(self):
-        # Test :meth:`Model.clone()
+        # Test :meth:`Model.clone() and :meth:`Model.has_parse_info()`.
 
         # Test model, component, variables
         m1 = myokit.load_model('example')
@@ -287,6 +287,10 @@ class ModelTest(unittest.TestCase):
         m1.reserve_unique_name_prefix('ostrich', 'turkey')
         m2 = m1.clone()
         self.assertEqual(m1, m2)
+
+        # Test tokens are not cloned
+        self.assertTrue(m1.has_parse_info())
+        self.assertFalse(m2.has_parse_info())
 
     def test_code(self):
         # Test :meth:`Model.code()`.
@@ -1215,11 +1219,25 @@ class ModelTest(unittest.TestCase):
     def test_show_line_of(self):
         # Test :meth:`Model.show_line_of(variable)`.
 
+        # Check string with info
         m = myokit.load_model('example')
-        e = m.show_line_of(m.get('ina.INa'))
+        v = m.get('ina.INa')
+        e = m.show_line_of(v)
         self.assertIn('Defined on line 91', e)
         self.assertIn('Intermediary variable', e)
         self.assertEqual(len(e.splitlines()), 4)
+
+        # Check with freshly made model
+        m2 = m.clone()
+        v2 = m2.get('ina.INa')
+        e = m2.show_line_of(v2)
+        self.assertNotIn('Defined on line', e)
+        self.assertIn('Intermediary variable', e)
+        self.assertEqual(len(e.splitlines()), 3)
+
+        # 'raw' version
+        self.assertEqual(m.show_line_of(v, raw=True), 91)
+        self.assertIsNone(m2.show_line_of(v2, raw=True))
 
         # Test deprecated alias
         with WarningCollector() as wc:


### PR DESCRIPTION
#589 

- adds has_parse_info()
- adds show_line_of(var, **raw**)
- adds Ctrl+J to jump to var def in ide