### PR TITLE
Travis updates: OpenCL on Ubuntu, faster OS/X install, Removed Python 2.7.6

### DIFF
--- a/.travis-opencl.sh
+++ b/.travis-opencl.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ev
+
+# Get Intel OpenCL Runtime
+# https://software.intel.com/en-us/articles/opencl-drivers#latest_CPU_runtime
+PACKAGE_URL=http://registrationcenter-download.intel.com/akdlm/irc_nas/12556/opencl_runtime_16.1.2_x64_rh_6.4.0.37.tgz
+PACKAGE_NAME=opencl_runtime_16.1.2_x64_rh_6.4.0.37
+
+wget -q ${PACKAGE_URL} -O /tmp/opencl_runtime.tgz
+tar -xzf /tmp/opencl_runtime.tgz -C /tmp
+sed 's/decline/accept/g' -i /tmp/${PACKAGE_NAME}/silent.cfg
+apt-get install -yq cpio
+/tmp/${PACKAGE_NAME}/install.sh -s /tmp/${PACKAGE_NAME}/silent.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ branches:
 
 # Python version choices:
 #
-# 2.7.0 --> Released 2010-07-03, not tested!
-# 2.7.6 --> Released 2013-11-10, earliest version testable on Travis
-#       --> Version shipped with Ubuntu LTS 14.04 (supported until 2019)
+# 2.7.0 --> Released 2010-07-03, no longer testable.
+# 2.7.6 --> Released 2013-11-10, no longer testable.
 # 2.7   --> Latest 2.7 version. At the moment 2.7.14 on travis (2018-10-31)
 # 3.0-3.3 --> Bad initial versions of Python 3; Not supported
 # 3.4     --> No longer supported by pip (2019-03)
@@ -27,86 +26,93 @@ branches:
 matrix:
     # Always put true env variable first, for nicer overview on travis website
     include:
-        # Unit tests on OS/X, running first because this one's slow
-        - os: osx
-          osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
-          language: shell
-          env:
-            - MYOKIT_UNIT=true
-        # Style checking
-        - python: "3.8"
-          env:
-            - MYOKIT_STYLE=true
-        # Doctests
-        - python: "3.8"
-          env:
-            - MYOKIT_DOC=true
         # Unit tests on Ubuntu
-        - python: "2.7.6"
-          dist: trusty
-          env:
-            - MYOKIT_UNIT=true
         - python: "2.7"
           env:
+            - PYTHON=python
             - MYOKIT_UNIT=true
         - python: "3.5"
           env:
+            - PYTHON=python3
             - MYOKIT_UNIT=true
         - python: "3.6"
           env:
+            - PYTHON=python3
             - MYOKIT_UNIT=true
         - python: "3.7"
           env:
+            - PYTHON=python3
             - MYOKIT_UNIT=true
         - python: "3.8"
           env:
+            - PYTHON=python3
             - MYOKIT_UNIT=true
         # Cover checking + latest version
         - python: "3.9"
           env:
+            - PYTHON=python3
             - MYOKIT_COVER=true
-        # Basic install test
+        # Style checking
+        - python: "3.9"
+          env:
+            - PYTHON=python3
+            - MYOKIT_STYLE=true
+        # Doctests
+        - python: "3.9"
+          env:
+            - PYTHON=python3
+            - MYOKIT_DOC=true
+        # Test without optional dependencies
         - python: "3.9"
           env:
             - MYOKIT_BASIC=true
+            - MYOKIT_UNIT=true
+        # Unit tests on OS/X
+        - os: osx
+          osx_image: xcode11.2
+          language: shell
+          env:
+            - PYTHON=python3
             - MYOKIT_UNIT=true
 
 # Install CVODE dependencies
 before_install:
   # Ubuntu
   # Python packages can be installed here but won't work (tests run in virtualenv)
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ ! $MYOKIT_STYLE ]]; then
       sudo apt-get -qq update;
       sudo apt-get install -y libsundials-serial-dev;
+      sudo apt-get install -y opencl-headers ocl-icd-opencl-dev;
+      sudo bash .travis-opencl.sh;
     fi;
   # OS/X
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update-reset;
+      export HOMEBREW_NO_AUTO_UPDATE=1;
       brew install sundials;
     fi;
 
 # Install Myokit and extra testing dependencies
 install:
-  - pip install --upgrade pip;
-  - if [[ $MYOKIT_BASIC == true ]]; then pip install .; else pip install .[optional]; fi;
-  - if [[ $MYOKIT_COVER == true ]]; then pip install coverage codecov; fi;
-  - if [[ $MYOKIT_STYLE == true ]]; then pip install .[dev]; fi;
-  - if [[ $MYOKIT_DOC == true ]]; then pip install .[docs,gui]; fi;
+  - $PYTHON -m pip install --upgrade pip;
+  - if [[ $MYOKIT_BASIC == true ]]; then $PYTHON -m pip install .; else $PYTHON -m pip install .[optional]; fi;
+  - if [[ $MYOKIT_COVER == true ]]; then $PYTHON -m pip install coverage codecov; fi;
+  - if [[ $MYOKIT_STYLE == true ]]; then $PYTHON -m pip install .[dev]; fi;
+  - if [[ $MYOKIT_DOC == true ]]; then $PYTHON -m pip install .[docs,gui]; fi;
 
 # Show system information
 before_script:
-- python -m myokit system
+- $PYTHON -m myokit system
 
 # Run tests
 script:
-  - if [[ $MYOKIT_UNIT == true ]]; then python -m myokit test unit; fi;
+  - if [[ $MYOKIT_UNIT == true ]]; then $PYTHON -m myokit test unit; fi;
   - if [[ $MYOKIT_COVER == true ]]; then coverage3 run -m myokit test unit; fi;
   - if [[ $MYOKIT_STYLE == true ]]; then
-        python -m flake8 --version;
-        python -m flake8;
+        $PYTHON -m flake8 --version;
+        $PYTHON -m flake8;
     fi;
   - if [[ $MYOKIT_DOC == true ]]; then
-        python -m myokit test doc;
+        $PYTHON -m myokit test doc;
     fi;
 
 # Compile coverage report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ This page lists the main changes made to Myokit in each release.
 
 ## Unreleased
 - Added
+  - [#682](https://github.com/MichaelClerx/myokit/pull/682) OpenCL code now recognises error code -1001.
+  - [#683](https://github.com/MichaelClerx/myokit/pull/683) Now testing OpenCL code in CI.
 - Changed
 - Deprecated
 - Removed
+  - [#683](https://github.com/MichaelClerx/myokit/pull/683) No longer testing on Python 2.7.6.
 - Fixed
   - [#684](https://github.com/MichaelClerx/myokit/pull/684) Fixed OpenCL loading issue on OS/X (with special thanks to Martin Aguilar and David Augustin).
 


### PR DESCRIPTION
- Removed Python 2.7.6 tests (which no longer ran)
- Added OpenCL headers and intel runtime for ubuntu tests
- Stopped OS/X from reinstalling 100s of packages with homebrew
- Made OS/X tests use python 3
