### PR TITLE
Path lists read from myokit.ini are now filtered for empty entries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This page lists the main changes made to Myokit in each release.
 - Fixed
   - [#684](https://github.com/MichaelClerx/myokit/pull/684) Fixed OpenCL loading issue on OS/X (with special thanks to Martin Aguilar and David Augustin).
   - [#686](https://github.com/MichaelClerx/myokit/pull/686) Fixed a (windows only) bug in `myokit.format_path()`.
+  - [#689](https://github.com/MichaelClerx/myokit/pull/689) Path lists read from `myokit.ini` are now filtered for empty entries and closing semicolons.
 
 ## [1.32.0] - 2021-01-19
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This page lists the main changes made to Myokit in each release.
   - [#682](https://github.com/MichaelClerx/myokit/pull/682) OpenCL code now recognises error code -1001.
   - [#683](https://github.com/MichaelClerx/myokit/pull/683) Now testing OpenCL code in CI.
 - Changed
+  - [#689](https://github.com/MichaelClerx/myokit/pull/689) In Python 2, an `ImportError` is now raised if `myokit.ini` contains the sequence " ;" in any of its value (as this cannot be processed by Python 2's `ConfigParser`).
 - Deprecated
 - Removed
   - [#683](https://github.com/MichaelClerx/myokit/pull/683) No longer testing on Python 2.7.6 on linux, or any Python 2.7 on Windows.

--- a/myokit/_config.py
+++ b/myokit/_config.py
@@ -191,7 +191,7 @@ def _load():
 
     # In Python <3.2, strings like "x ; y" are treated as "x" followed by a
     # comment. These shouldn't appear in myokit ini files!
-    if sys.hexversion < 0x03020000:
+    if sys.hexversion < 0x03020000:     # pragma: no cover
         with open(path, 'r') as f:
             lines = f.readlines()
 

--- a/myokit/_config.py
+++ b/myokit/_config.py
@@ -245,11 +245,9 @@ def _load():
 
     # Sundials libraries, header files, and version
     if config.has_option('sundials', 'lib'):
-        for x in config.get('sundials', 'lib').split(';'):
-            myokit.SUNDIALS_LIB.append(x.strip())
+        myokit.SUNDIALS_LIB.extend(_path_list(config.get('sundials', 'lib')))
     if config.has_option('sundials', 'inc'):
-        for x in config.get('sundials', 'inc').split(';'):
-            myokit.SUNDIALS_INC.append(x.strip())
+        myokit.SUNDIALS_INC.extend(_path_list(config.get('sundials', 'inc')))
     if config.has_option('sundials', 'version'):
         try:
             myokit.SUNDIALS_VERSION = int(config.get('sundials', 'version'))
@@ -278,11 +276,9 @@ def _load():
 
     # OpenCL libraries and header files
     if config.has_option('opencl', 'lib'):
-        for x in config.get('opencl', 'lib').split(';'):
-            myokit.OPENCL_LIB.append(x.strip())
+        myokit.OPENCL_LIB.extend(_path_list(config.get('opencl', 'lib')))
     if config.has_option('opencl', 'inc'):
-        for x in config.get('opencl', 'inc').split(';'):
-            myokit.OPENCL_INC.append(x.strip())
+        myokit.OPENCL_INC.extend(_path_list(config.get('opencl', 'inc')))
 
 
 def _dynamically_add_embedded_sundials_win():   # pragma: no linux cover
@@ -301,6 +297,10 @@ def _dynamically_add_embedded_sundials_win():   # pragma: no linux cover
         myokit.SUNDIALS_LIB.append(os.path.join(sundials_win, 'lib'))
     if len(myokit.SUNDIALS_INC) == 0:
         myokit.SUNDIALS_INC.append(os.path.join(sundials_win, 'include'))
+
+
+def _path_list(text):
+    return [x for x in [x.strip() for x in text.split(';')] if x != '']
 
 
 # Load settings

--- a/myokit/tests/test_config.py
+++ b/myokit/tests/test_config.py
@@ -41,21 +41,21 @@ inc = three;eight
 # Config with empty paths and spaces
 config_empties_1 = """
 [sundials]
-lib =
+lib = five
 inc = three;four;
 [opencl]
 lib = one;;   two point five;three;
-inc = five
+inc =
 """
 
 # Config with empty paths and " ;", which in Python 2 is ignored
 config_empties_2 = """
 [sundials]
-lib =
+lib = five ; six
 inc = three;four;
 [opencl]
 lib = one ;;   two point five ;three;
-inc = five ; six
+inc =
 """
 
 # Qt options
@@ -174,12 +174,12 @@ class TestConfig(unittest.TestCase):
                 with open(d.path('myokit.ini'), 'w') as f:
                     f.write(config_empties_1)
                 config._load()
-                self.assertEqual(myokit.SUNDIALS_LIB, [])
+                self.assertEqual(myokit.SUNDIALS_LIB, ['five'])
                 self.assertEqual(myokit.SUNDIALS_INC, ['three', 'four'])
                 self.assertEqual(
                     myokit.OPENCL_LIB,
                     ['one', 'two point five', 'three'])
-                self.assertEqual(myokit.OPENCL_INC, ['five'])
+                self.assertEqual(myokit.OPENCL_INC, [])
 
                 # Even if the list contains " ;", which Python 2's config
                 # parser treats as a comment
@@ -193,12 +193,12 @@ class TestConfig(unittest.TestCase):
                     self.assertRaises(ImportError, config._load)
                 else:
                     config._load()
-                    self.assertEqual(myokit.SUNDIALS_LIB, [])
+                    self.assertEqual(myokit.SUNDIALS_LIB, ['five', 'six'])
                     self.assertEqual(myokit.SUNDIALS_INC, ['three', 'four'])
                     self.assertEqual(
                         myokit.OPENCL_LIB,
                         ['one', 'two point five', 'three'])
-                    self.assertEqual(myokit.OPENCL_INC, ['five', 'six'])
+                    self.assertEqual(myokit.OPENCL_INC, [])
 
                 # Qt gui options
                 with open(d.path('myokit.ini'), 'w') as f:

--- a/myokit/tests/test_config.py
+++ b/myokit/tests/test_config.py
@@ -39,13 +39,23 @@ inc = three;eight
 """
 
 # Config with empty paths and spaces
-config_empties = """
+config_empties_1 = """
 [sundials]
 lib =
-inc = three;
+inc = three;four;
+[opencl]
+lib = one;;   two point five;three;
+inc = five
+"""
+
+# Config with empty paths and " ;", which in Python 2 is ignored
+config_empties_2 = """
+[sundials]
+lib =
+inc = three;four;
 [opencl]
 lib = one ;;   two point five ;three;
-inc = five
+inc = five ; six
 """
 
 # Qt options
@@ -155,28 +165,6 @@ class TestConfig(unittest.TestCase):
                 self.assertEqual(myokit.OPENCL_LIB, ['five', 'six'])
                 self.assertEqual(myokit.OPENCL_INC, ['three', 'eight'])
 
-                # Full values, PySide gui
-                myokit.SUNDIALS_LIB = []
-                myokit.SUNDIALS_INC = []
-                myokit.OPENCL_LIB = []
-                myokit.OPENCL_INC = []
-                myokit.FORCE_PYSIDE = myokit.FORCE_PYSIDE2 = False
-                myokit.FORCE_PYQT4 = myokit.FORCE_PYQT5 = False
-                with open(d.path('myokit.ini'), 'w') as f:
-                    f.write(config2)
-                config._load()
-                self.assertEqual(myokit.DATE_FORMAT, 'TEST_DATE_FORMAT')
-                self.assertEqual(myokit.TIME_FORMAT, 'TEST_TIME_FORMAT')
-                self.assertTrue(myokit.DEBUG_LINE_NUMBERS)
-                self.assertFalse(myokit.FORCE_PYSIDE)
-                self.assertFalse(myokit.FORCE_PYSIDE2)
-                self.assertFalse(myokit.FORCE_PYQT4)
-                self.assertFalse(myokit.FORCE_PYQT5)
-                self.assertEqual(myokit.SUNDIALS_LIB, ['one', 'two'])
-                self.assertEqual(myokit.SUNDIALS_INC, ['three', 'four'])
-                self.assertEqual(myokit.OPENCL_LIB, ['five', 'six'])
-                self.assertEqual(myokit.OPENCL_INC, ['three', 'eight'])
-
                 # Lists of paths should be filtered for empty values and
                 # trimmed
                 myokit.SUNDIALS_LIB = []
@@ -184,14 +172,33 @@ class TestConfig(unittest.TestCase):
                 myokit.OPENCL_LIB = []
                 myokit.OPENCL_INC = []
                 with open(d.path('myokit.ini'), 'w') as f:
-                    f.write(config_empties)
+                    f.write(config_empties_1)
                 config._load()
                 self.assertEqual(myokit.SUNDIALS_LIB, [])
-                self.assertEqual(myokit.SUNDIALS_INC, ['three'])
+                self.assertEqual(myokit.SUNDIALS_INC, ['three', 'four'])
                 self.assertEqual(
                     myokit.OPENCL_LIB,
                     ['one', 'two point five', 'three'])
                 self.assertEqual(myokit.OPENCL_INC, ['five'])
+
+                # Even if the list contains " ;", which Python 2's config
+                # parser treats as a comment
+                myokit.SUNDIALS_LIB = []
+                myokit.SUNDIALS_INC = []
+                myokit.OPENCL_LIB = []
+                myokit.OPENCL_INC = []
+                with open(d.path('myokit.ini'), 'w') as f:
+                    f.write(config_empties_2)
+                if sys.hexversion < 0x03020000:
+                    self.assertRaises(ImportError, config._load)
+                else:
+                    config._load()
+                    self.assertEqual(myokit.SUNDIALS_LIB, [])
+                    self.assertEqual(myokit.SUNDIALS_INC, ['three', 'four'])
+                    self.assertEqual(
+                        myokit.OPENCL_LIB,
+                        ['one', 'two point five', 'three'])
+                    self.assertEqual(myokit.OPENCL_INC, ['five', 'six'])
 
                 # Qt gui options
                 with open(d.path('myokit.ini'), 'w') as f:

--- a/myokit/tests/test_config.py
+++ b/myokit/tests/test_config.py
@@ -38,6 +38,16 @@ lib = five;six
 inc = three;eight
 """
 
+# Config with empty paths and spaces
+config_empties = """
+[sundials]
+lib =
+inc = three;
+[opencl]
+lib = one ;;   two point five ;three;
+inc = five
+"""
+
 # Qt options
 config_pyside = """
 [gui]
@@ -144,6 +154,44 @@ class TestConfig(unittest.TestCase):
                 self.assertEqual(myokit.SUNDIALS_INC, ['three', 'four'])
                 self.assertEqual(myokit.OPENCL_LIB, ['five', 'six'])
                 self.assertEqual(myokit.OPENCL_INC, ['three', 'eight'])
+
+                # Full values, PySide gui
+                myokit.SUNDIALS_LIB = []
+                myokit.SUNDIALS_INC = []
+                myokit.OPENCL_LIB = []
+                myokit.OPENCL_INC = []
+                myokit.FORCE_PYSIDE = myokit.FORCE_PYSIDE2 = False
+                myokit.FORCE_PYQT4 = myokit.FORCE_PYQT5 = False
+                with open(d.path('myokit.ini'), 'w') as f:
+                    f.write(config2)
+                config._load()
+                self.assertEqual(myokit.DATE_FORMAT, 'TEST_DATE_FORMAT')
+                self.assertEqual(myokit.TIME_FORMAT, 'TEST_TIME_FORMAT')
+                self.assertTrue(myokit.DEBUG_LINE_NUMBERS)
+                self.assertFalse(myokit.FORCE_PYSIDE)
+                self.assertFalse(myokit.FORCE_PYSIDE2)
+                self.assertFalse(myokit.FORCE_PYQT4)
+                self.assertFalse(myokit.FORCE_PYQT5)
+                self.assertEqual(myokit.SUNDIALS_LIB, ['one', 'two'])
+                self.assertEqual(myokit.SUNDIALS_INC, ['three', 'four'])
+                self.assertEqual(myokit.OPENCL_LIB, ['five', 'six'])
+                self.assertEqual(myokit.OPENCL_INC, ['three', 'eight'])
+
+                # Lists of paths should be filtered for empty values and
+                # trimmed
+                myokit.SUNDIALS_LIB = []
+                myokit.SUNDIALS_INC = []
+                myokit.OPENCL_LIB = []
+                myokit.OPENCL_INC = []
+                with open(d.path('myokit.ini'), 'w') as f:
+                    f.write(config_empties)
+                config._load()
+                self.assertEqual(myokit.SUNDIALS_LIB, [])
+                self.assertEqual(myokit.SUNDIALS_INC, ['three'])
+                self.assertEqual(
+                    myokit.OPENCL_LIB,
+                    ['one', 'two point five', 'three'])
+                self.assertEqual(myokit.OPENCL_INC, ['five'])
 
                 # Qt gui options
                 with open(d.path('myokit.ini'), 'w') as f:


### PR DESCRIPTION
and closing semicolons. Closes #688.