### PR TITLE
OpenCL sim connections with double precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This page lists the main changes made to Myokit in each release.
   - [#689](https://github.com/MichaelClerx/myokit/pull/689) Path lists read from `myokit.ini` are now filtered for empty entries and closing semicolons.
   - [#744](https://github.com/MichaelClerx/myokit/pull/744) Fixed a bug in `OpenCLSimulation.find_nan()`, that occurred for very small simulations (e.g. 2 cells).
   - [#744](https://github.com/MichaelClerx/myokit/pull/744) Fixed a bug in `OpenCLSimulation` that made it impossible to use `set_connections()` with double precision.
+  - [#744](https://github.com/MichaelClerx/myokit/pull/744) Fixed a bug in `OpenCLSimulation` that made it impossible to use `set_connections()` on Python 2.
 
 ## [1.32.0] - 2021-01-19
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This page lists the main changes made to Myokit in each release.
   - [#735](https://github.com/MichaelClerx/myokit/pull/735) The new module `myokit.tools` contains several stand-alone tools that are used by Myokit and were previously in the main `myokit` namespace or not part of the public API.
   - [#735](https://github.com/MichaelClerx/myokit/pull/735) The method `pid_hash`, which is used by compiled code to generate (hopefully) unique ids is now part of the public API.
   - [#744](https://github.com/MichaelClerx/myokit/pull/744) Added a method `myokit.OpenCL.supported_and_available` to check if OpenCL is supported and at least one OpenCL device is detected.
+  - [#744](https://github.com/MichaelClerx/myokit/pull/744) Added a method `myokit.OpenCL.test_extension_on_current_platform(x)` that checks if OpenCL extension `x` is available on the currently selected platform.
 - Changed
   - [#581](https://github.com/MichaelClerx/myokit/pull/581) Powers are now rendered without spaces in mmt code, e.g. `x^2` instead of `x ^ 2`.
   - [#595](https://github.com/MichaelClerx/myokit/pull/595) The `Simulation` class now uses CVODES instead of CVODE as backend, which may require changes to your installation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ This page lists the main changes made to Myokit in each release.
   - [#684](https://github.com/MichaelClerx/myokit/pull/684) Fixed OpenCL loading issue on OS/X (with special thanks to Martin Aguilar and David Augustin).
   - [#686](https://github.com/MichaelClerx/myokit/pull/686) Fixed a (windows only) bug in `myokit.tools.format_path()`.
   - [#689](https://github.com/MichaelClerx/myokit/pull/689) Path lists read from `myokit.ini` are now filtered for empty entries and closing semicolons.
+  - [#744](https://github.com/MichaelClerx/myokit/pull/744) Fixed a bug in `OpenCLSimulation.find_nan()`, that occurred for very small simulations (e.g. 2 cells).
+  - [#744](https://github.com/MichaelClerx/myokit/pull/744) Fixed a bug in `OpenCLSimulation` that made it impossible to use `set_connections()` with double precision.
 
 ## [1.32.0] - 2021-01-19
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This page lists the main changes made to Myokit in each release.
   - [#735](https://github.com/MichaelClerx/myokit/pull/735) The new module `myokit.float` contains several functions related to floating point numbers that were previously in the main `myokit` namespace or not part of the public API.
   - [#735](https://github.com/MichaelClerx/myokit/pull/735) The new module `myokit.tools` contains several stand-alone tools that are used by Myokit and were previously in the main `myokit` namespace or not part of the public API.
   - [#735](https://github.com/MichaelClerx/myokit/pull/735) The method `pid_hash`, which is used by compiled code to generate (hopefully) unique ids is now part of the public API.
+  - [#744](https://github.com/MichaelClerx/myokit/pull/744) Added a method `myokit.OpenCL.supported_and_available` to check if OpenCL is supported and at least one OpenCL device is detected.
 - Changed
   - [#581](https://github.com/MichaelClerx/myokit/pull/581) Powers are now rendered without spaces in mmt code, e.g. `x^2` instead of `x ^ 2`.
   - [#595](https://github.com/MichaelClerx/myokit/pull/595) The `Simulation` class now uses CVODES instead of CVODE as backend, which may require changes to your installation.

--- a/myokit/_sim/fiber_tissue.py
+++ b/myokit/_sim/fiber_tissue.py
@@ -788,6 +788,7 @@ class FiberTissueSimulation(myokit.CModule):
             'diffusion': True,
             'fields': [],
             'rl_states': {},
+            'connections': False,
         }
         args['model'] = self._modelf
         args['vmvar'] = self._vmf

--- a/myokit/_sim/mcl.h
+++ b/myokit/_sim/mcl.h
@@ -79,7 +79,7 @@ mcl_flag2(const char* msg, const cl_int flag)
     if(strcmp(msg, "")) {
         sprintf(sub, " (%s)", msg);
     } else {
-        sprintf(sub, "");
+        sub[0] = 0;
     }
 
     switch(flag) {
@@ -290,6 +290,10 @@ int mcl_select_device(
     // OpenCL ints for iterating
     cl_uint i, j;
 
+    // By default, don't recommend a platform or device
+    *pid = NULL;
+    *did = NULL;
+
     // Check input
     const char* pname;
     const char* dname;
@@ -337,9 +341,6 @@ int mcl_select_device(
 
     // Platform unspecified
     if (platform == Py_None) {
-
-        // Don't recommend a platform
-        *pid = NULL;
 
         // No platform or device specified
         if (device == Py_None) {

--- a/myokit/_sim/opencl.c
+++ b/myokit/_sim/opencl.c
@@ -34,10 +34,104 @@ info(PyObject *self, PyObject *args)
 }
 
 /*
+ * Tests building a program and returns the 
+ *
+ * If the program builds successfully, None is returned. If the program fails
+ * to compile a string containing the compiler output is returned. If something
+ * else goes wrong an exception is raised.
+ */
+static PyObject*
+build(PyObject* self, PyObject* args)
+{
+    // OpenCL flag
+    cl_int flag;
+
+    // OpenCL context
+    cl_context context;
+
+    // Platform and device name (Python bytes) and ids
+    PyObject *platform_name;
+    PyObject *device_name;
+    cl_platform_id platform_id;
+    cl_device_id device_id;
+    
+    // Program and source
+    cl_program program;
+    PyObject *kernel_source;
+
+    // Compilation error message
+    size_t blog_size;
+    char *blog;
+    
+    // Success?
+    int build_ok = 0;
+    int exception = 0;
+
+    // Check input arguments
+    if(!PyArg_ParseTuple(args, "OOs", &platform_name, &device_name, &kernel_source)) {
+        // Nothing allocated yet, no pyobjects _created_, return directly
+        PyErr_SetString(PyExc_Exception, "Wrong number of arguments.");
+        return 0;
+    }
+
+    // Get platform and device id
+    if (mcl_select_device(platform_name, device_name, &platform_id, &device_id)) {
+        return 0;
+    }
+
+    // Create a context
+    if (platform_id != NULL) {
+        cl_context_properties context_properties[] = { CL_CONTEXT_PLATFORM, (cl_context_properties)platform_id, 0};
+        context = clCreateContext(context_properties, 1, &device_id, NULL, NULL, &flag);
+    } else {
+        context = clCreateContext(NULL, 1, &device_id, NULL, NULL, &flag);
+    }
+    if(mcl_flag2("context", flag)) {
+        return 0;
+    }
+    // From this point on, clean up if aborting.
+
+    // Compile the program
+    program = clCreateProgramWithSource(context, 1, (const char**)&kernel_source, NULL, &flag);
+    if(mcl_flag(flag)) {
+        exception = 1;
+    } else {
+    
+        flag = clBuildProgram(program, 1, &device_id, "", NULL, NULL);
+        if(flag == CL_SUCCESS) {
+            build_ok = 1;
+        } else if (flag == CL_BUILD_PROGRAM_FAILURE) {
+            build_ok = 0;
+        } else if (mcl_flag(flag)) {
+            exception = 1;
+        }
+        
+        // Extract build log
+        if (!exception) {
+            clGetProgramBuildInfo(program, device_id, CL_PROGRAM_BUILD_LOG, 0, NULL, &blog_size);
+            blog = (char*)malloc(blog_size);
+            clGetProgramBuildInfo(program, device_id, CL_PROGRAM_BUILD_LOG, blog_size, blog, NULL);
+        }
+    }
+
+    // Clean
+    clReleaseProgram(program);
+    clReleaseContext(context);
+
+    // Return
+    if (exception) {
+        return 0;
+    } else {
+        return PyUnicode_FromStringAndSize(blog, (Py_ssize_t)blog_size);
+    }
+}
+
+/*
  * Methods in this module
  */
 static PyMethodDef SimMethods[] = {
     {"info", info, METH_VARARGS, "Get some information about OpenCL devices."},
+    {"build", build, METH_VARARGS, "Try building an OpenCL kernel program."},
     {NULL},
 };
 

--- a/myokit/_sim/opencl.c
+++ b/myokit/_sim/opencl.c
@@ -34,7 +34,7 @@ info(PyObject *self, PyObject *args)
 }
 
 /*
- * Tests building a program and returns the 
+ * Tests building a program and returns the
  *
  * If the program builds successfully, None is returned. If the program fails
  * to compile a string containing the compiler output is returned. If something
@@ -54,7 +54,7 @@ build(PyObject* self, PyObject* args)
     PyObject *device_name;
     cl_platform_id platform_id;
     cl_device_id device_id;
-    
+
     // Program and source
     cl_program program;
     PyObject *kernel_source;
@@ -62,7 +62,7 @@ build(PyObject* self, PyObject* args)
     // Compilation error message
     size_t blog_size;
     char *blog;
-    
+
     // Success?
     int build_ok = 0;
     int exception = 0;
@@ -96,7 +96,7 @@ build(PyObject* self, PyObject* args)
     if(mcl_flag(flag)) {
         exception = 1;
     } else {
-    
+
         flag = clBuildProgram(program, 1, &device_id, "", NULL, NULL);
         if(flag == CL_SUCCESS) {
             build_ok = 1;
@@ -105,7 +105,7 @@ build(PyObject* self, PyObject* args)
         } else if (mcl_flag(flag)) {
             exception = 1;
         }
-        
+
         // Extract build log
         if (!exception) {
             clGetProgramBuildInfo(program, device_id, CL_PROGRAM_BUILD_LOG, 0, NULL, &blog_size);

--- a/myokit/_sim/opencl.c
+++ b/myokit/_sim/opencl.c
@@ -64,7 +64,6 @@ build(PyObject* self, PyObject* args)
     char *blog;
 
     // Success?
-    int build_ok = 0;
     int exception = 0;
 
     // Check input arguments
@@ -98,19 +97,14 @@ build(PyObject* self, PyObject* args)
     } else {
 
         flag = clBuildProgram(program, 1, &device_id, "", NULL, NULL);
-        if(flag == CL_SUCCESS) {
-            build_ok = 1;
-        } else if (flag == CL_BUILD_PROGRAM_FAILURE) {
-            build_ok = 0;
-        } else if (mcl_flag(flag)) {
-            exception = 1;
-        }
-
-        // Extract build log
-        if (!exception) {
+        if((flag == CL_SUCCESS) || (flag == CL_BUILD_PROGRAM_FAILURE)) {
+            // Extract build log
             clGetProgramBuildInfo(program, device_id, CL_PROGRAM_BUILD_LOG, 0, NULL, &blog_size);
             blog = (char*)malloc(blog_size);
             clGetProgramBuildInfo(program, device_id, CL_PROGRAM_BUILD_LOG, blog_size, blog, NULL);
+        } else {
+            mcl_flag(flag);
+            exception = 1;
         }
     }
 

--- a/myokit/_sim/opencl.py
+++ b/myokit/_sim/opencl.py
@@ -225,14 +225,17 @@ class OpenCL(myokit.CModule):
             return False
 
     @staticmethod
-    def test_extension_on_current_platform(extension):
+    def test_extension_on_current_platform(extension, raw=False):
         """
         Tries building a program on the currently selected platform and device
         (or the defaults, if none are explicitly selected) that does nothing
         except enabling the given ``extension``.
 
-        Returns ``True`` if the name of the extension appears in the compiler
-        output (which is taken to indicate a warning).
+        By default, the method returns ``True`` if the name of the extension
+        does not appear in the compiler output (which is taken to indicate a
+        warning).
+        This can be changed by setting ``raw=True``, in which case the raw
+        compiler output will be returned.
 
         This method can be used to test if an exception is available on the
         selected or default device (rather than querying a specific device).
@@ -250,7 +253,9 @@ class OpenCL(myokit.CModule):
         out = cl.build(platform, device, code)
 
         # Check output and return
-        return 'unsupported OpenCL extension' not in out
+        if raw:
+            return out
+        return extension not in out
 
 
 class OpenCLInfo(object):

--- a/myokit/_sim/opencl.py
+++ b/myokit/_sim/opencl.py
@@ -155,7 +155,7 @@ class OpenCL(myokit.CModule):
 
     @staticmethod
     def save_selection(platform=None, device=None):
-        """"
+        """
         Stores a platform/device selection to disk.
 
         Both platform and device are identified by their names.
@@ -212,7 +212,7 @@ class OpenCL(myokit.CModule):
             return True
         except NoOpenCLError:
             return False
-            
+
     @staticmethod
     def supported_and_available():
         """
@@ -220,34 +220,35 @@ class OpenCL(myokit.CModule):
         at least one (platform and) device were detected.
         """
         try:
-            return OpenCL._get_instance().device_available()
+            return OpenCL.info().device_available()
         except NoOpenCLError:
             return False
 
     @staticmethod
-    def supports_double_precision_atomics():
+    def test_extension_on_current_platform(extension):
         """
-        Returns ``True`` if OpenCL support has been detected, and has support
-        for atomic comparison of double-precision sized objects.
-        
-        In particular, the method checks that the following extensions can be
-        used: `cl_khr_fp64`, and `cl_khr_int64_base_atomics`.        
+        Tries building a program on the currently selected platform and device
+        (or the defaults, if none are explicitly selected) that does nothing
+        except enabling the given ``extension``.
+
+        Returns ``True`` if the name of the extension appears in the compiler
+        output (which is taken to indicate a warning).
+
+        This method can be used to test if an exception is available on the
+        selected or default device (rather than querying a specific device).
         """
         try:
             cl = OpenCL._get_instance()
         except NoOpenCLError as e:
             return False
-        
+
         # Get preferred platform/device combo from configuration file
         platform, device = myokit.OpenCL.load_selection_bytes()
 
-        # Create code and run       
-        code = '\n'.join([
-            '#pragma OPENCL EXTENSION cl_khr_fp64 : enable',
-            '#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable',
-        ])        
+        # Create code and run
+        code = '#pragma OPENCL EXTENSION ' + str(extension) + ' : enable\n'
         out = cl.build(platform, device, code)
-        
+
         # Check output and return
         return 'unsupported OpenCL extension' not in out
 

--- a/myokit/_sim/openclsim.c
+++ b/myokit/_sim/openclsim.c
@@ -568,8 +568,6 @@ sim_init(PyObject* self, PyObject* args)
     #endif
 
     // Get platform and device id
-    platform_id = NULL;
-    device_id = NULL;
     if (mcl_select_device(platform_name, device_name, &platform_id, &device_id)) {
         // Error message set by mcl_select_device
         return sim_clean();

--- a/myokit/_sim/openclsim.c
+++ b/myokit/_sim/openclsim.c
@@ -529,18 +529,31 @@ sim_init(PyObject* self, PyObject* args)
                 PyErr_SetString(PyExc_Exception, "Connections list must contain only 3-tuples");
                 return sim_clean();
             }
+
             ret = PyTuple_GetItem(flt, 0);  // Borrowed reference
-            if(!PyLong_Check(ret)) {
+            if(PyLong_Check(ret)) {
+                rvec_conn1[i] = (int)PyLong_AsLong(ret);
+#if PY_MAJOR_VERSION < 3
+            } else if (PyInt_Check(ret)) {
+                rvec_conn1[i] = (int)PyInt_AsLong(ret);
+#endif
+            } else {
                 PyErr_SetString(PyExc_Exception, "First item in each connection tuple must be int");
                 return sim_clean();
             }
-            rvec_conn1[i] = (int)PyLong_AsLong(ret);
+
             ret = PyTuple_GetItem(flt, 1);  // Borrowed reference
-            if(!PyLong_Check(ret)) {
+            if(PyLong_Check(ret)) {
+                rvec_conn2[i] = (int)PyLong_AsLong(ret);
+#if PY_MAJOR_VERSION < 3
+            } else if(PyInt_Check(ret)) {
+                rvec_conn2[i] = (int)PyInt_AsLong(ret);
+#endif
+            } else {
                 PyErr_SetString(PyExc_Exception, "Second item in each connection tuple must be int");
                 return sim_clean();
             }
-            rvec_conn2[i] = (int)PyLong_AsLong(ret);
+
             ret = PyTuple_GetItem(flt, 2);  // Borrowed reference
             if(!PyFloat_Check(ret)) {
                 PyErr_SetString(PyExc_Exception, "Third item in each connection tuple must be float");

--- a/myokit/_sim/openclsim.py
+++ b/myokit/_sim/openclsim.py
@@ -959,6 +959,7 @@ class SimulationOpenCL(myokit.CModule):
             'fields': self._fields.keys(),
             'paced_cells': self._paced_cells,
             'rl_states': self._rl_states,
+            'connections': self._connections is not None,
         }
         if myokit.DEBUG:
             print('-' * 79)

--- a/myokit/_sim/openclsim.py
+++ b/myokit/_sim/openclsim.py
@@ -611,6 +611,9 @@ class SimulationOpenCL(myokit.CModule):
 
         # Search for first occurrence of error in the detailed log
         ifirst, kfirst = find_error_position(log)
+        if ifirst is None:
+            ifirst = 0
+            kfirst = next(iter(log.items()))[0]
 
         # Get indices of cell in state vector
         ndims = len(self._dims)
@@ -646,7 +649,7 @@ class SimulationOpenCL(myokit.CModule):
         var = self._model.get('.'.join(kfirst.split('.')[ndims:]))
 
         # Get value causing error
-        value = states[1][var.indice()]
+        value = states[1 if ifirst > 0 else 0][var.indice()]
         var = var.qname()
 
         # Get time error occurred
@@ -1193,8 +1196,12 @@ class SimulationOpenCL(myokit.CModule):
         For a model with currents in ``[uA/uF]`` and voltage in ``[mV]``,
         `gx`` and ``gy`` have the unit ``[mS/uF]``.
         """
-        self._gx = float(gx)
-        self._gy = float(gy)
+        gx, gy = float(gx), float(gy)
+        if gx < 0:
+            raise ValueError('Invalid conductance gx=' + str(gx))
+        if gy < 0:
+            raise ValueError('Invalid conductance gx=' + str(gy))
+        self._gx, self._gy = gx, gy
 
     def set_connections(self, connections):
         """

--- a/myokit/tests/data/br-1977.mmt
+++ b/myokit/tests/data/br-1977.mmt
@@ -1,0 +1,129 @@
+[[model]]
+name: Beeler-Reuter-1977
+desc: """
+The 1977 Beeler Reuter model of the AP in ventricular myocytes.
+
+Implemented in Myokit following the equations found in [1].
+
+[1] Reconstruction of the action potential of ventricular myocardial fibres
+    G.W. Beeler and H. Reuter
+    1977, The Journal of Physiology
+
+"""
+# Initial values:
+membrane.V = -84.622
+ina.m      = 0.01
+ina.h      = 0.99
+ina.j      = 0.98
+isi.d      = 0.003
+isi.f      = 0.99
+ix1.x1     = 0.0004
+isi.Cai    = 2e-7
+
+[engine]
+time = 0 bind time
+pace = 0 bind pace
+
+[stimulus]
+amplitude = -25 [uA/cm^2]
+IStim = engine.pace * amplitude
+
+[membrane]
+C = 1 [uF/cm^2] : The membrane capacitance
+dot(V) = -(1/C) * (ik1.IK1 + ix1.Ix1 + ina.INa + isi.Isi + stimulus.IStim + IDiff)
+    in [mV]
+    desc: Membrane potential
+    label membrane_potential
+IDiff = 0 bind diffusion_current
+    in [uF/cm^2]
+
+[ina]
+use membrane.V as V
+gNaBar = 4 [mS/cm^2]
+gNaC = 0.003 [mS/cm^2]
+ENa = 50 [mV]
+INa = (gNaBar * m^3 * h * j + gNaC) * (V - ENa)
+    in [uA/cm^2]
+    desc: The excitatory inward sodium current
+dot(m) =  alpha * (1 - m) - beta * m
+    alpha = (V + 47) / (1 - exp(-0.1 * (V + 47)))
+    beta  = 40 * exp(-0.056 * (V + 72))
+    desc: The activation parameter
+dot(h) =  alpha * (1 - h) - beta * h
+    alpha = 0.126 * exp(-0.25 * (V + 77))
+    beta  = 1.7 / (1 + exp(-0.082 * (V + 22.5)))
+    desc: An inactivation parameter
+dot(j) =  alpha * (1 - j) - beta * j
+    alpha = 0.055 * exp(-0.25 * (V + 78)) / (1 + exp(-0.2 * (V + 78)))
+    beta  = 0.3 / (1 + exp(-0.1 * (V + 32)))
+    desc: An inactivation parameter
+
+[isi]
+use membrane.V as V
+gsBar = 0.09
+Es = -82.3 - 13.0287 * log(Cai)
+    in [mV]
+Isi = gsBar * d * f * (V - Es)
+    in [uA/cm^2]
+    desc: """
+    The slow inward current, primarily carried by calcium ions. Called either
+    "iCa" or "is" in the paper.
+    """
+dot(d) =  alpha * (1 - d) - beta * d
+    alpha = 0.095 * exp(-0.01 * (V + -5)) / (exp(-0.072 * (V + -5)) + 1)
+    beta  = 0.07 * exp(-0.017 * (V + 44)) / (exp(0.05 * (V + 44)) + 1)
+dot(f) = alpha * (1 - f) - beta * f
+    alpha = 0.012 * exp(-0.008 * (V + 28)) / (exp(0.15 * (V + 28)) + 1)
+    beta  = 0.0065 * exp(-0.02 * (V + 30)) / (exp(-0.2 * (V + 30)) + 1)
+dot(Cai) = -1e-7 * Isi + 0.07 * (1e-7 - Cai)
+    desc: The intracellular Calcium concentration
+    in [mol/L]
+
+[ik1]
+use membrane.V as V
+IK1 = 0.35 * (
+        4 * (exp(0.04 * (V + 85)) - 1)
+        / (exp(0.08 * (V + 53)) + exp(0.04 * (V + 53)))
+        + 0.2 * (V + 23)
+        / (1 - exp(-0.04 * (V + 23)))
+    )
+    in [uA/cm^2]
+    desc: """A time-independent outward potassium current exhibiting
+          inward-going rectification"""
+
+[ix1]
+use membrane.V as V
+Ix1 = x1 * 0.8 * (exp(0.04 * (V + 77)) - 1) / exp(0.04 * (V + 35))
+    in [uA/cm^2]
+    desc: """A voltage- and time-dependent outward current, primarily carried
+          by potassium ions"""
+dot(x1) = alpha * (1 - x1) - beta * x1
+    alpha = 0.0005 * exp(0.083 * (V + 50)) / (exp(0.057 * (V + 50)) + 1)
+    beta  = 0.0013 * exp(-0.06 * (V + 20)) / (exp(-0.04 * (V + 333)) + 1)
+
+[[protocol]]
+# Level  Start    Length   Period   Multiplier
+1.0      100      2        1000     0
+
+[[script]]
+import matplotlib.pyplot as plt
+import myokit
+
+#
+# This example file plots a single AP using the model develope by Beeler
+# and Reuter.
+#
+
+# Get model and protocol, create simulation
+m = get_model()
+p = get_protocol()
+s = myokit.Simulation(m, p)
+
+# Run simulation
+d = s.run(1000)
+
+# Display the result
+plt.figure()
+plt.plot(d['engine.time'], d['membrane.V'])
+plt.show()
+

--- a/myokit/tests/shared.py
+++ b/myokit/tests/shared.py
@@ -31,7 +31,7 @@ DIR_IO = os.path.join(DIR_DATA, 'io')
 DIR_FORMATS = os.path.join(DIR_DATA, 'formats')
 
 # OpenCL support
-OpenCL_FOUND = myokit.OpenCL.supported()
+OpenCL_FOUND = myokit.OpenCL.supported_and_available()
 
 
 class TemporaryDirectory(object):

--- a/myokit/tests/shared.py
+++ b/myokit/tests/shared.py
@@ -32,6 +32,9 @@ DIR_FORMATS = os.path.join(DIR_DATA, 'formats')
 
 # OpenCL support
 OpenCL_FOUND = myokit.OpenCL.supported_and_available()
+OpenCL_DOUBLE_PRECISION_CONNECTIONS = (
+    OpenCL_FOUND and myokit.OpenCL.test_extension_on_current_platform(
+        'cl_khr_int64_base_atomics'))
 
 
 class TemporaryDirectory(object):

--- a/test.py
+++ b/test.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-import myokit
-
-print(myokit.OpenCL.test_extension_on_current_platform('pooh-bear'))

--- a/test.py
+++ b/test.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import myokit
+
+print(myokit.OpenCL.test_extension_on_current_platform('pooh-bear'))


### PR DESCRIPTION
See #743 

The atomic add operation for floating points only works on floats. Replaced with a version that (1) fixes this, and (2) avoids another possible problem (see https://streamhpc.com/blog/2016-02-09/atomic-operations-for-floats-in-opencl-improved)