### PR TITLE
Deal with empty <cn> in mathml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ This page lists the main changes made to Myokit in each release.
   - [#744](https://github.com/MichaelClerx/myokit/pull/744) Fixed a bug in `OpenCLSimulation` that made it impossible to use `set_connections()` with double precision.
   - [#744](https://github.com/MichaelClerx/myokit/pull/744) Fixed a bug in `OpenCLSimulation` that made it impossible to use `set_connections()` on Python 2.
   - [#754](https://github.com/MichaelClerx/myokit/pull/754) Improved error message when an `OpenCLSimulation` with double precision is run on a device that does not support it.
+  - [#766](https://github.com/MichaelClerx/myokit/pull/766) Improved error message when an empty MathML `<cn>` element is encountered.
 
 ## [1.32.0] - 2021-01-19
 - Added

--- a/myokit/formats/mathml/_parser.py
+++ b/myokit/formats/mathml/_parser.py
@@ -721,6 +721,8 @@ class MathMLParser(object):
                     element)
 
             # Get value
+            if element.text is None:
+                raise MathMLError('Empty <cn> element', element)
             try:
                 value = float(element.text.strip())
             except ValueError:
@@ -739,6 +741,8 @@ class MathMLParser(object):
                     element)
 
             # Get value
+            if element.text is None:
+                raise MathMLError('Empty <cn> element', element)
             try:
                 value = int(element.text.strip(), base)
             except ValueError:
@@ -749,6 +753,8 @@ class MathMLParser(object):
         elif kind == 'double':
             # Floating point (positive, negative, exponents, etc)
 
+            if element.text is None:
+                raise MathMLError('Empty <cn> element', element)
             try:
                 value = float(element.text.strip())
             except ValueError:

--- a/myokit/tests/test_formats_mathml_content.py
+++ b/myokit/tests/test_formats_mathml_content.py
@@ -718,6 +718,10 @@ class ContentMathMLParserTest(unittest.TestCase):
             mathml.MathMLError, 'Unsupported <cn> type',
             self.p, '<cn type="special">1</cn>')
 
+        # Missing value
+        self.assertRaisesRegex(
+            mathml.MathMLError, 'Missing value', self.p, '<cn />')
+
     def test_trig_basic(self):
         # Test parsing basic trig functions
 

--- a/myokit/tests/test_formats_mathml_content.py
+++ b/myokit/tests/test_formats_mathml_content.py
@@ -720,7 +720,16 @@ class ContentMathMLParserTest(unittest.TestCase):
 
         # Missing value
         self.assertRaisesRegex(
-            mathml.MathMLError, 'Missing value', self.p, '<cn />')
+            mathml.MathMLError, 'Empty <cn>', self.p, '<cn />')
+        self.assertRaisesRegex(
+            mathml.MathMLError, 'Empty <cn>',
+            self.p, '<cn kind="real" />')
+        self.assertRaisesRegex(
+            mathml.MathMLError, 'Empty <cn>',
+            self.p, '<cn kind="integer" />')
+        self.assertRaisesRegex(
+            mathml.MathMLError, 'Empty <cn>',
+            self.p, '<cn kind="double" />')
 
     def test_trig_basic(self):
         # Test parsing basic trig functions

--- a/myokit/tests/test_formats_mathml_content.py
+++ b/myokit/tests/test_formats_mathml_content.py
@@ -723,13 +723,13 @@ class ContentMathMLParserTest(unittest.TestCase):
             mathml.MathMLError, 'Empty <cn>', self.p, '<cn />')
         self.assertRaisesRegex(
             mathml.MathMLError, 'Empty <cn>',
-            self.p, '<cn kind="real" />')
+            self.p, '<cn type="real" />')
         self.assertRaisesRegex(
             mathml.MathMLError, 'Empty <cn>',
-            self.p, '<cn kind="integer" />')
+            self.p, '<cn type="integer" />')
         self.assertRaisesRegex(
             mathml.MathMLError, 'Empty <cn>',
-            self.p, '<cn kind="double" />')
+            self.p, '<cn type="double" />')
 
     def test_trig_basic(self):
         # Test parsing basic trig functions


### PR DESCRIPTION
Currently raises attribute error, should be informative parse error