### PR TITLE
Fix bug in calculate_conductance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This page lists the main changes made to Myokit in each release.
   - [#754](https://github.com/MichaelClerx/myokit/pull/754) Added a method `myokit.OpenCL.current_info(x)` that returns information about the currently selected platform and device; support of OpenCL extensions can then be checked with `OpenCLPlatformInfo.has_extension`.
   - [#754](https://github.com/MichaelClerx/myokit/pull/754) Improved error message when an `OpenCLSimulation` with double precision is run on a device that does not support it.
   - [#763](https://github.com/MichaelClerx/myokit/pull/763) Added a method `OpenCLSimulation.set_conductance_field` to apply heterogeneous conductance on a rectangular grid.
+  - [#776](https://github.com/MichaelClerx/myokit/pull/776) Added a method `OpenCLSimulation.monodomain_conductance` to replace the deprecated method `calculate_conductance`.
 - Changed
   - [#581](https://github.com/MichaelClerx/myokit/pull/581) Powers are now rendered without spaces in mmt code, e.g. `x^2` instead of `x ^ 2`.
   - [#595](https://github.com/MichaelClerx/myokit/pull/595) The `Simulation` class now uses CVODES instead of CVODE as backend, which may require changes to your installation.
@@ -42,6 +43,7 @@ This page lists the main changes made to Myokit in each release.
   - [#735](https://github.com/MichaelClerx/myokit/pull/735) The method `myokit.format_path` is deprecated in favour of `myokit.tools.format_path`.
   - [#735](https://github.com/MichaelClerx/myokit/pull/735) The method `myokit.strfloat` is deprecated in favour of `myokit.float.str`.
   - [#758](https://github.com/MichaelClerx/myokit/pull/758) The class `myokit.FiberTissueSimulation` is deprecated and will be removed in future versions.
+  - [#776](https://github.com/MichaelClerx/myokit/pull/776) The method `OpenCLSimulation.calculate_conductance` is deprecated in favour of the new method `calculate_conductance`, which takes slightly different parameters.
 - Removed
   - [#683](https://github.com/MichaelClerx/myokit/pull/683) No longer testing on Python 2.7.6 on linux (still testing latest 2.7). No longer testing any Python 2.7 on Windows.
   - [#730](https://github.com/MichaelClerx/myokit/pull/730) Removed the method `myokit.pack_snapshot`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import sphinx
 import myokit
 
 
@@ -34,16 +33,10 @@ extensions = [
 ]
 
 # Autodoc defaults
-if int(sphinx.__version__.split('.')[1]) < 8:
-    autodoc_default_flags = [
-        'members',
-        #'inherited-members',	# Also drags in all PyQt docstrings etc.
-    ]
-else:
-    autodoc_default_options = {
-        'members': None,
-        #'inherited-members': None,
-    }
+autodoc_default_options = {
+    'members': None,
+    #'inherited-members': None,
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/examples/t4-opencl-simulation.ipynb
+++ b/examples/t4-opencl-simulation.ipynb
@@ -23,13 +23,13 @@
     "We assume each cell model contains a membrane potential variable, defined by an equation:\n",
     "\n",
     "\\begin{equation}\n",
-    "\\frac{d V}{d t}=-\\frac{1}{C_{m}}(i_{\\mathit{ion}}+i_{\\mathit{stim}}+i_{\\mathit{diff}})\\label{eq:dv/dt}\n",
+    "\\frac{d V}{d t}=-\\frac{1}{C_{m}}(I_{\\mathit{ion}}+I_{\\mathit{stim}}+I_{\\mathit{diff}})\\label{eq:dv/dt}\n",
     "\\end{equation}\n",
     "\n",
-    "where $i_\\mathit{diff}$ is a diffusion current\n",
+    "where $I_\\mathit{diff}$ is a diffusion current\n",
     "\n",
     "\\begin{equation}\n",
-    "i_{\\mathit{diff},i}=\\sum_{j\\in N_{i}}g_{ij}\\left(V_{i}-V_{j}\\right)\\label{eq:idiff}\n",
+    "I_{\\mathit{diff},i}=\\sum_{j\\in N_{i}}g_{ij}\\left(V_{i}-V_{j}\\right)\\label{eq:idiff}\n",
     "\\end{equation}\n",
     "\n",
     "and \n",
@@ -83,9 +83,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Heterogeneous parameters\n",
+    "## Heterogeneous parameters (scalar fields)\n",
     "\n",
-    "The `SimulationOpenCL` allows _literal constants_ (constants that do not depend on other constants) to be set using a _scalar field_, i.e. to specify a value per cell."
+    "The `SimulationOpenCL` allows _literal constants_ (constants that do not depend on other constants) to be set using a *scalar field*, i.e. to specify a value per cell."
    ]
   },
   {
@@ -116,7 +116,7 @@
     "but we now need to take into account that a cell i's external inputs $u_i$ depends on $y_i$, plus those of its neighbours:\n",
     "\n",
     "\\begin{equation}\n",
-    "\\dot{y_i}(t)=f\\left(y_i(t),u_i(y, t), t, p_i\\right)\n",
+    "\\dot{y_i}(t)=f\\left(y_i(t),u_i(t), t, p_i\\right)\n",
     "\\end{equation}\n",
     "\n",
     "Here we write $f$ for each cell, instead of $f_i$, to indicate the function is the same (we use the same model for every cell).\n",
@@ -128,89 +128,190 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Relationship to mono-domain equations\n",
-    "\n",
-    "The bidomain model starts from the assumption of ohmic conductance currents as in the equation above.\n",
-    "It then adds a few components representing the extracellular conductance and generalises the result to a continuous PDE.\n",
-    "The mono-domain is derived from the bi-domain model by dropping the terms explicitly modelling the extracellular conductance.\n",
-    "Many modelers then assume only conduction in the principal directions (x,y and z) and add the boundary condition that no current enters or leaves the system at the sides.\n",
-    "Then, using a finite-difference approximation of the second order derivatives arising from the bidomain equations,\n",
-    "we arrive right back at the original equation specifying ohmic conductance between neighbouring cells.\n",
-    "\n",
-    "While the PDE form is highly advantageous when discretising to an arbitrary-shaped mesh, for simple cell-to-cell conductance models it has the disadvantage of introducing extra parameters (with perhaps a less clear meaning than $g_{x}$ and $g_{y}$).\n",
-    "However, in order to compare results in Myokit with mono-domain simulations, it may be necessary to translate beteen the used parameter sets.\n",
-    "Their relationship is derived below.\n",
-    "\n",
-    "According to the mono-domain model, each point in the heart can be described as:\n",
+    "## Relationship to monodomain model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the monodomain model (see [Leon & Horacek, 1991](https://doi.org/10.1016/0022-0736(91)90077-Y) or [Wikipedia](https://en.wikipedia.org/wiki/Monodomain_model )), the electrophysiology of an infinitesimal point in a tissue is described by:\n",
     "\n",
     "\\begin{equation}\n",
-    "\\frac{\\lambda}{1+\\lambda}\\nabla\\cdot\\left(\\Sigma_{i}\\nabla v\\right)=\\chi\\left(C_{m}\\frac{\\partial v}{\\partial t}+i_{\\mathit{ion}}+i_{\\mathit{stim}}\\right)\\label{eq:monodom}\n",
+    "\\frac{\\partial V}{\\partial t} =\n",
+    "-\\frac{1}{c_m}\n",
+    "\\left(\n",
+    "    -\\frac{1}{\\chi}\n",
+    "    \\frac{k}{k + 1}\n",
+    "    \\nabla \\cdot D_i \\nabla V\n",
+    "    + i_\\text{ion}\n",
+    "    + i_\\text{stim}\n",
+    "\\right)\n",
     "\\end{equation}\n",
     "\n",
-    "With:\n",
+    "where\n",
     "\n",
-    "- $\\lambda$ The intra- to extracellular conductivity ratio\n",
-    "- $\\Sigma_{i}$ A tensor representing the intracellular conductivity\n",
-    "- $v$ The local membrane potential\n",
-    "- $\\chi$ The surface area of the membrane per unit volume\n",
-    "- $C_{m}$ Capacitance per unit area\n",
-    "- $i_{ion}$ Ionic current per unit area\n",
+    "$V$ is the local membrane potential (e.g. in V),\n",
     "\n",
-    "Assuming all currents are normalised to unit area, we can combine this with the equation for $\\frac{\\partial V}{\\partial t}$ to find the mono-domain equation for $i_{diff}$:\n",
+    "$i_\\text{ion}$ is the transmembrane current per unit area (e.g. in A/m^2),\n",
     "\n",
-    "\\begin{eqnarray*}\n",
-    "\\frac{\\lambda}{1+\\lambda}\\nabla\\cdot\\left(\\Sigma_{i}\\nabla V\\right) & = & \\chi\\left(C_{m}\\frac{\\partial V}{\\partial t}+i_{\\mathit{ion}}+i_{\\mathit{stim}}\\right)\\\\\n",
-    "\\frac{\\lambda}{\\chi\\left(1+\\lambda\\right)}\\nabla\\cdot\\left(\\Sigma_{i}\\nabla V\\right) & = & C_{m}\\frac{\\partial V}{\\partial t}+i_{\\mathit{ion}}+i_{\\mathit{stim}}\\\\\n",
-    "\\frac{\\partial V}{\\partial t} & = & \\frac{-1}{C_{m}}\\left(i_{\\mathit{ion}}+i_{\\mathit{stim}}-\\frac{1}{\\chi}\\frac{\\lambda}{\\left(1+\\lambda\\right)}\\nabla\\cdot\\left(\\Sigma_{i}\\nabla V\\right)\\right)\\\\\n",
-    " & = & \\frac{-1}{C_{m}}\\left(i_{\\mathit{ion}}+i_{\\mathit{stim}}+i_{\\mathit{diff}}\\right)\n",
-    "\\end{eqnarray*}\n",
+    "$i_\\text{stim}$ is the applied stimulus current per unit area (e.g. in A/m^2),\n",
     "\n",
-    "so that\n",
+    "$c_m$ is the membrane capacitance per unit area (e.g. in C/m^2, but usually given as $1\\mu F/\\textit{cm}^2$),\n",
+    "\n",
+    "$\\chi$ is the surface area of the membrane per unit of volume (e.g. in m^2/m^3),\n",
+    "\n",
+    "$D_i$ is a tensor representing intracellular conductivity (e.g. in S/m), and\n",
+    "\n",
+    "$k$ is the ratio between intra- and extracellular conductivity."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Equating this to \n",
     "\n",
     "\\begin{equation}\n",
-    "i_{\\mathit{diff}}=-\\frac{1}{\\chi}\\frac{\\lambda}{\\left(1+\\lambda\\right)}\\nabla\\cdot\\left(\\Sigma_{i}\\nabla V\\right)\n",
+    "\\frac{\\partial V}{\\partial t} = -\\frac{1}{c_m}(i_\\text{ion} + i_\\text{stim} + i_\\text{diff})\n",
     "\\end{equation}\n",
     "\n",
-    "For the 2D case, let\n",
+    "we find\n",
     "\n",
     "\\begin{equation}\n",
-    "\\Sigma_{i}=\\sigma_{x}\\hat{\\mathbf{i}}+\\sigma_{y}\\hat{\\mathbf{j}}\n",
+    "i_\\text{diff}\n",
+    "    = -\\frac{1}{\\chi} \\frac{k}{k + 1} \\nabla \\cdot D_i \\nabla V\n",
+    "    = -\\nabla \\cdot \\tilde{D} \\nabla V\n",
     "\\end{equation}\n",
     "\n",
-    "then\n",
+    "where \n",
     "\n",
     "\\begin{equation}\n",
-    "\\Sigma_{i}\\nabla V=\\frac{\\partial V}{\\partial x}\\sigma_{x}\\hat{\\mathbf{i}}+\\frac{\\partial V}{\\partial y}\\sigma_{y}\\hat{\\mathbf{j}}\n",
-    "\\end{equation}\n",
+    "    \\tilde{D} = \\frac{1}{\\chi}\\frac{k}{k + 1}D_i\n",
+    "\\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using [finite differences](https://en.wikipedia.org/wiki/Finite_difference#Higher-order_differences) we can discretise this on a 1-dimensional regular grid to obtain\n",
     "\n",
-    "and\n",
+    "\\begin{align}\n",
+    "i_\\text{diff}\n",
+    "    &= -\\nabla \\cdot \\tilde{D} \\nabla V \\\\\n",
+    "    &= -\\tilde{D} \\frac{\\partial^{2}V}{\\partial x^{2}} \\\\\n",
+    "    &= -\\tilde{D} \\left( \\frac{V_{i + 1} - 2 V_i + V_{i - 1}}{\\Delta x^{2}}\\right) \\\\\n",
+    "    &=  \\tilde{D} \\frac{1}{\\Delta x^{2}}\\sum_{j \\in N}\\left(V_i-V_j\\right)\n",
+    "\\end{align}\n",
+    "\n",
+    "where $\\Delta x$ is the spacing between subsequent points on the grid, and the final sum is taken over the set of neighbouring points $N$.\n",
+    "Note that we can use the same equation for points at the edges, which is equivalent to assuming zero-flux boundary conditions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using this expression, we can write\n",
     "\n",
     "\\begin{equation}\n",
-    "\\nabla\\cdot\\left(\\Sigma_{i}\\nabla V\\right)=\\frac{\\partial^{2}V}{\\partial x^{2}}\\sigma_{x}+\\frac{\\partial^{2}V}{\\partial y^{2}}\\sigma_{y}\n",
+    "\\frac{dV}{dt} = -\\frac{1}{c_m} (i_\\text{ion} + i_\\text{stim} + i_\\text{diff})\n",
+    "\\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For models with currents in $\\mu A / \\textit{cm}^2$ we can use this equation directly.\n",
+    "To use unnormalised currents, we replace the specific capacitance with total capacitance, to find\n",
+    "\n",
+    "\\begin{equation}\n",
+    "\\frac{dV}{dt} = -\\frac{1}{C_m} (I_\\text{ion} + I_\\text{stim} + I_\\text{diff})\n",
+    "\\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Two-dimensional"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In two dimensions, and assuming a diagonal conductivity tensor with values $\\tilde{D_x}$ and $\\tilde{D_y}$, we can follow a similar procedure on a grid with spacing $\\Delta x$ and $\\Delta y$to find\n",
+    "\n",
+    "\\begin{align}\n",
+    "i_\\text{diff}\n",
+    "    = \\frac{\\tilde{D_x}}{\\Delta x^{2}} \\sum_{j \\in N_x}(V_i - V_j)\n",
+    "    + \\frac{\\tilde{D_y}}{\\Delta y^{2}} \\sum_{j \\in N_y}(V_i - V_j) \\\\\n",
+    "\\end{align}\n",
+    "\n",
+    "where $N_x$ and $N_y$ are the sets of neighbours in the directions corresponding to $\\tilde{D_x}$ and $\\tilde{D_y}$ respectively."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Converting parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Assuming a rectangular grid with constant conductances $D_{i}$, we can write\n",
+    "\n",
+    "\\begin{equation}\n",
+    "i_\\text{diff}\n",
+    "    = \\tilde{D} \\frac{1}{\\Delta x^{2}}\\sum_{j \\in N}\\left(V_{i}-V_{x}\\right)\n",
+    "    = \\bar{g} \\sum_{j \\in N}\\left(V_{i}-V_{x}\\right)\n",
     "\\end{equation}\n",
     "\n",
-    "A finite difference approximation of $\\frac{\\partial^{2}V}{\\partial x^{2}}$ is\n",
+    "to find\n",
     "\n",
-    "\\begin{eqnarray*}\n",
-    "\\frac{\\partial^{2}V}{\\partial x^{2}} & = & \\frac{V_{i-1}-2V_{i}+V_{i+1}}{\\Delta x^{2}}\\\\\n",
-    " & = & -\\left(\\frac{V_{i}-V_{i-1}}{\\Delta x^{2}}+\\frac{V_{i}-V_{i+1}}{\\Delta x^{2}}\\right)\\\\\n",
-    " & = & \\frac{-1}{\\Delta x^{2}}\\sum_{j\\in N_{x}}\\left(V_{i}-V_{x}\\right)\n",
-    "\\end{eqnarray*}\n",
+    "\\begin{equation}\n",
+    "\\bar{g} = \\frac{\\tilde{D}}{\\Delta x^2} = \\frac{1}{\\Delta x^2}\\frac{1}{\\chi}\\frac{k}{k + 1}D_i\n",
+    "\\end{equation}\n",
     "\n",
-    "where $N_{x}$ is the set of neighbours of cell $i$ in the $x$ direction.\n",
-    "Using this approximation, we find:\n",
+    "where $\\bar{g}$ is cell-to-cell conductance per unit membrane area."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In unnormalised form, we obtain\n",
     "\n",
-    "\\begin{eqnarray*}\n",
-    "i_{\\mathit{diff}} & = & \\frac{\\sigma_{x}}{\\chi\\Delta x^{2}}\\frac{\\lambda}{1+\\lambda}\\sum_{j\\in N_{x}}\\left(V_{i}-V_{x}\\right)+\\frac{\\sigma_{y}}{\\chi\\Delta y^{2}}\\frac{\\lambda}{1+\\lambda}\\sum_{j\\in N_{y}}\\left(V_{i}-V_{y}\\right)\\\\\n",
-    " & = & g_{x}\\sum_{x\\in N_{x}}\\left(V_{i}-V_{x}\\right)+g_{y}\\sum_{y\\in N_{y}}\\left(V_{i}-V_{y}\\right)\\\\\n",
-    " & = & \\sum g_{ij}\\left(V_{i}-V_{j}\\right)\n",
-    "\\end{eqnarray*}\n",
+    "\\begin{equation}\n",
+    "g = A_m \\frac{1}{\\Delta x^2}\\frac{1}{\\chi}\\frac{k}{k + 1}D_i\n",
+    "\\end{equation}\n",
     "\n",
-    "So to convert the four mono-domain parameters to a single conductance, we use:\n",
-    "\\begin{eqnarray*}\n",
-    "g_{x} & = & \\frac{\\lambda\\sigma_{x}}{\\chi\\left(1+\\lambda\\right)\\Delta x^{2}}\\\\\n",
-    "g_{y} & = & \\frac{\\lambda\\sigma_{y}}{\\chi\\left(1+\\lambda\\right)\\Delta y^{2}}\n",
-    "\\end{eqnarray*}"
+    "where $A_m$ is the surface area of the cell membrane encompassed by each \"node\" of our discretisation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Converting parameters: heterogeneity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please note, however, that $g_{ij}$ is defined *between* cells/nodes while $\\tilde{D}$ is defined *for* each node.\n",
+    "This difference is unproblematic in homogeneous simulations, but leads to some difficulties if hetereogeneity is introduced.\n",
+    "\n",
+    "For example, if the conductivity can vary spatially, then $\\nabla \\cdot \\tilde{D} \\nabla V \\neq \\tilde{D} \\frac{\\partial^{2}V}{\\partial x^{2}} $, and the equation for $g_{ij}$ becomes dependent on the spatial derivative of $\\tilde{D}$.\n",
+    "\n",
+    "Similarly, if using unnormalised models there is no way to choose an $A_m$ *per connection*, rather than per cell."
    ]
   },
   {

--- a/examples/t4-opencl-simulation.ipynb
+++ b/examples/t4-opencl-simulation.ipynb
@@ -195,17 +195,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using [finite differences](https://en.wikipedia.org/wiki/Finite_difference#Higher-order_differences) we can discretise this on a 1-dimensional regular grid to obtain\n",
+    "Using [finite differences](https://en.wikipedia.org/wiki/Finite_difference#Higher-order_differences) we can discretise this on a 1-dimensional regular grid to obtain an expression for the diffusion current in node $i$\n",
     "\n",
     "\\begin{align}\n",
-    "i_\\text{diff}\n",
+    "i_{\\text{diff}, i}\n",
     "    &= -\\nabla \\cdot \\tilde{D} \\nabla V \\\\\n",
     "    &= -\\tilde{D} \\frac{\\partial^{2}V}{\\partial x^{2}} \\\\\n",
     "    &= -\\tilde{D} \\left( \\frac{V_{i + 1} - 2 V_i + V_{i - 1}}{\\Delta x^{2}}\\right) \\\\\n",
     "    &=  \\tilde{D} \\frac{1}{\\Delta x^{2}}\\sum_{j \\in N}\\left(V_i-V_j\\right)\n",
     "\\end{align}\n",
     "\n",
-    "where $\\Delta x$ is the spacing between subsequent points on the grid, and the final sum is taken over the set of neighbouring points $N$.\n",
+    "where $\\Delta x$ is the spacing between subsequent points on the grid, and the sum is taken over the set of points neighbouring $i$.\n",
     "Note that we can use the same equation for points at the edges, which is equivalent to assuming zero-flux boundary conditions."
    ]
   },

--- a/myokit/_sim/openclsim.py
+++ b/myokit/_sim/openclsim.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 #
 # OpenCL driven simulation, 1d or 2d
 #
@@ -342,7 +343,7 @@ class SimulationOpenCL(myokit.CModule):
         warnings.warn('The method SimulationOpenCL.calculate_conductance() is'
                       ' deprecated. Please use monodomain_conductance()'
                       ' instead.')
-        return self.monodomain_conductance(1 / one_over_chi, r, sx, dx, 1)
+        return self.monodomain_conductance(1 / chi, r, sx, dx, 1)
 
     def conductance(self):
         """

--- a/myokit/tests/test_simulation_opencl.py
+++ b/myokit/tests/test_simulation_opencl.py
@@ -68,13 +68,20 @@ class SimulationOpenCLTest(unittest.TestCase):
             self._s2 = myokit.SimulationOpenCL(self.m, self.p, ncells=(4, 3))
         return self._s2
 
-    def test_calculate_conductance(self):
-        # Test the calculate_conductance() method.
-        r, sx, chi, dx = 2, 3.4, 5.6, 7.8
+    def test_monodomain_conductance(self):
+        # Test the method to calculate g from monodomain parameters
+        k, D, chi, dx, A = 2, 3.4, 5.6, 7.8, 3
+        g = D * k / ((k + 1) * chi * dx * dx)
+        # Arguments: chi, k, D, dx, A
         self.assertEqual(
-            self.s0.calculate_conductance(r, sx, chi, dx),
-            r * sx * chi / ((1 + r) * dx * dx)
-        )
+            self.s0.monodomain_conductance(chi, k, D, dx, A), g * A)
+
+        # Test the deprecated calculate_conductance() method.
+        with WarningCollector() as c:
+            # Arguments: r, sx, one_over_chi, dx
+            self.assertEqual(
+                self.s0.calculate_conductance(k, D, 1 / chi, dx), g)
+        self.assertIn('deprecated', c.text())
 
     def test_conductance(self):
         # Tests setting and getting conductance.


### PR DESCRIPTION
Replaced `OpenCLSimulation.calculate_conductance` with a method `monodomain_conductance` (which takes slightly different parameters).

Fixes #772 