### PR TITLE
Sensitivity ordering bug

### DIFF
--- a/myokit/_sim/cmodel.h
+++ b/myokit/_sim/cmodel.h
@@ -607,6 +607,9 @@ Model_SetParametersFromIndependents(Model model, const realtype* independents)
     int i, j;
     if (model == NULL) return Model_INVALID_MODEL;
 
+    /* Note: this method assumes that parameters are ordered in the same way
+             as independents. */
+
     /* Scan for changes */
     i = 0;
     j = 0;

--- a/myokit/tests/test_simulation_cvodes.py
+++ b/myokit/tests/test_simulation_cvodes.py
@@ -361,7 +361,8 @@ class SimulationTest(unittest.TestCase):
             [dose]
             absorption_rate = 0.1
                 in [S/F (1.1574074074074077e-05)]
-            dot(drug_amount) = -absorption_rate * drug_amount + central.dose_rate
+            dot(drug_amount) = (-absorption_rate * drug_amount
+                                + central.dose_rate)
                 in [kg (1e-06)]
 
             [e]


### PR DESCRIPTION
See #759 

This was a really sneaky one: the method that let CVODES change the parameters for its finite difference scheme was using the wrong ordering, so CVODES got the ordering of the parameters wrong.