### PR TITLE
Pickling, hash & equality details

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,6 +10,7 @@ exclude=
     ./myokit/formats/python/template,
     ./build,
     ./venv,
+    ./venv2,
 ignore=
     # Block comment should start with '# '
     # Not if it's a commented out line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This page lists the main changes made to Myokit in each release.
   - [#845](https://github.com/MichaelClerx/myokit/pull/845) Improved syntax highlighting and automatic detection of "dark mode" themes.
   - [#849](https://github.com/MichaelClerx/myokit/pull/849) Trying to pickle a `myokit.Expression` now raises a more helpful error message.
   - [#849](https://github.com/MichaelClerx/myokit/pull/849) The method `myokit.parse_expression()` now accepts a `Model` as a context.
+  - [#849](https://github.com/MichaelClerx/myokit/pull/849) Model comparison with `==` now only returns ``True`` if both operands are the same object. Comparison based on code can be performed with `Model.is_similar()`.
 - Deprecated
 - Removed
 - Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This page lists the main changes made to Myokit in each release.
 - Fixed
   - [#841](https://github.com/MichaelClerx/myokit/pull/841) The MathMLExpressionWriter now uses `type="e-notation"` where necessary, instead of writing e.g. `1e-6`.
   - [#849](https://github.com/MichaelClerx/myokit/pull/849) If `Model.get()` and `Component.get()` now raise a `ValueError` if a component or variable from a different model is passed in.
+  - [#849](https://github.com/MichaelClerx/myokit/pull/849) `Equation` objects are now immutable, and their `hash` is consistent during the object's lifetime.
+  - [#849](https://github.com/MichaelClerx/myokit/pull/849) The `hash` of a `Quantity` object is now consistent during its lifetime, regardless of unit representations.
 
 ## [1.33.1] - 2022-01-24
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This page lists the main changes made to Myokit in each release.
 - Removed
 - Fixed
   - [#841](https://github.com/MichaelClerx/myokit/pull/841) The MathMLExpressionWriter now uses `type="e-notation"` where necessary, instead of writing e.g. `1e-6`.
-  - [#849](https://github.com/MichaelClerx/myokit/pull/849) If `Model.get()` and `Component.get()` are now called with a `Component` or `Variable` as argument, this is returned directly _only_ if it is part of the same model. In all other cases the object is converted to a qname before look-up.
+  - [#849](https://github.com/MichaelClerx/myokit/pull/849) If `Model.get()` and `Component.get()` now raise a `ValueError` if a component or variable from a different model is passed in.
 
 ## [1.33.1] - 2022-01-24
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ This page lists the main changes made to Myokit in each release.
   - [#843](https://github.com/MichaelClerx/myokit/pull/843) Myokit is no longer tested on Python 3.5.
   - [#844](https://github.com/MichaelClerx/myokit/pull/844) Tweaked the CellML export's `initial_value` attribute to strip `e+00` if present.
   - [#845](https://github.com/MichaelClerx/myokit/pull/845) Improved syntax highlighting and automatic detection of "dark mode" themes.
+  - [#849](https://github.com/MichaelClerx/myokit/pull/849) Trying to pickle a `myokit.Expression` now raises a more helpful error message.
+  - [#849](https://github.com/MichaelClerx/myokit/pull/849) The method `myokit.parse_expression()` now accepts a `Model` as a context.
 - Deprecated
 - Removed
 - Fixed
   - [#841](https://github.com/MichaelClerx/myokit/pull/841) The MathMLExpressionWriter now uses `type="e-notation"` where necessary, instead of writing e.g. `1e-6`.
+  - [#849](https://github.com/MichaelClerx/myokit/pull/849) If `Model.get()` and `Component.get()` are now called with a `Component` or `Variable` as argument, this is returned directly _only_ if it is part of the same model. In all other cases the object is converted to a qname before look-up.
 
 ## [1.33.1] - 2022-01-24
 - Added

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -140,6 +140,8 @@ class Expression(object):
         - if the given ``component`` has an alias for the variable, this alias
           is used.
         """
+        # Note: Because variable and component names can change, the output of
+        # code can not be cached (for non-literal expressions).
         b = StringIO()
         self._code(b, component)
         return b.getvalue()
@@ -342,6 +344,8 @@ class Expression(object):
             return False
         else:
             # Compare cached polish expression (which uses ids)
+            # Note that the polish representation uses object ids instead of
+            # qnames
             return self._polish() == other._polish()
 
     def eval(self, subst=None, precision=myokit.DOUBLE_PRECISION):
@@ -1166,11 +1170,6 @@ class Derivative(LhsExpression):
             return PartialDerivative(self, lhs)
         return None
 
-    def __eq__(self, other):
-        if type(other) != Derivative:
-            return False
-        return self._op == other._op
-
     def _eval_unit(self, mode):
         # Get numerator (never None in strict mode)
         unit1 = self._op._eval_unit(mode)
@@ -1287,11 +1286,6 @@ class PartialDerivative(LhsExpression):
         raise NotImplementedError(
             'Partial derivatives of partial derivatives are not supported.')
 
-    def __eq__(self, other):
-        if type(other) != PartialDerivative:
-            return False
-        return (self._var1 == other._var1) and (self._var2 == other._var2)
-
     def _eval_unit(self, mode):
         unit1 = self._var1._eval_unit(mode)
         unit2 = self._var2._eval_unit(mode)
@@ -1385,11 +1379,6 @@ class InitialValue(LhsExpression):
     def _diff(self, lhs, idstates):
         raise NotImplementedError(
             'Partial derivatives of initial conditions are not supported.')
-
-    def __eq__(self, other):
-        if type(other) != InitialValue:
-            return False
-        return self._var == other._var
 
     def _eval_unit(self, mode):
         return self._var._eval_unit(mode)

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -676,10 +676,11 @@ class Expression(object):
     def __reduce__(self):
         """ Called when attempting to pickle an expression. """
         raise NotImplementedError(
-            'Individual Myokit expressions can not be pickled. Please try e.g.'
-            ' pickling a full model, or use e.g. `pickled = Expression.code()`'
-            ' as a serialisation that can be "unpickled" with'
-            ' `myokit.parse_expression(pickled, context=a_model)`.')
+            'Individual myokit Expressions can not be pickled. Please try e.g.'
+            ' pickling a full model, or pickling the output of'
+            ' `Expression.code()` and following unpickling with a call to'
+            ' `myokit.parse_expression(unpickled_code, context=a_model)` to'
+            ' recreate the Expression.')
 
     def references(self):
         """

--- a/myokit/_expressions.py
+++ b/myokit/_expressions.py
@@ -1059,7 +1059,15 @@ class Name(LhsExpression):
     def __eq__(self, other):
         if type(other) != Name:
             return False
-        return self._value == other._value
+        if self._proper:
+            # Value is name? Then just check with is
+            return self._value is other._value
+        else:
+            # Debug thing? Then convert to string and see if the
+            # representations match. (This is the same as what would happen if
+            # __eq__ was called on an expression _containing_ a Name, e.g
+            # myokit.PrefixPlus(myokit.Name(1.23)).
+            return self.code() == other.code()
 
     def is_name(self, var=None):
         """See :meth:`Expression.is_name()`."""

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -4437,9 +4437,7 @@ class Variable(VarOwner):
             self._remove_variable_internal(kid)
 
     def rename(self, new_name):
-        """
-        Renames this variable.
-        """
+        """ Renames this variable. """
         assert(self._parent is not None)
         self._parent.move_variable(self, self._parent, new_name)
 

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -608,7 +608,8 @@ class VarOwner(ModelPart, VarProvider):
         if isinstance(name, ModelPart):
             if name.model() is self._model:
                 return name
-            name = name.qname()
+            raise ValueError(
+                'Given argument ' + repr(name) + ' is from a different model.')
 
         # Find variable
         names = name.split('.')
@@ -1627,7 +1628,8 @@ class Model(ObjectWithMeta, VarProvider):
         if isinstance(name, ModelPart):
             if name.model() is self:
                 return name
-            name = name.qname()
+            raise ValueError(
+                'Given argument ' + repr(name) + ' is from a different model.')
 
         # Split name, get different parts
         names = name.split('.')

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -777,6 +777,11 @@ class Model(ObjectWithMeta, VarProvider):
 
     Meta-data properties can be accessed via the property ``meta``, for example
     ``model.meta['key']= 'value'``.
+
+    For consistency with components, variables, and expressions, models cannot
+    be compared with ``==`` (which will only return ``True`` if both operands
+    are the same object). Checking if models are the same in other senses can
+    be done with :meth:`is_similar`. Models can be serialised with ``pickle``.
     """
     def __init__(self, name=None):
         super(Model, self).__init__()
@@ -1308,23 +1313,6 @@ class Model(ObjectWithMeta, VarProvider):
                 for v in c.variables(deep=deep, sort=sort):
                     yield v
         return stream(self)
-
-    def __eq__(self, other):
-        """
-        Checks if this model equals the ``other`` model.
-
-        This checks equality of code(), but also unique names and unique name
-        prefixes.
-        """
-        if self is other:
-            return True
-        if not isinstance(other, Model):
-            return False
-        if self._reserved_unames != other._reserved_unames:
-            return False
-        if self._reserved_uname_prefixes != other._reserved_uname_prefixes:
-            return False
-        return self.code() == other.code()
 
     def evaluate_derivatives(
             self, state=None, inputs=None, precision=myokit.DOUBLE_PRECISION,
@@ -1980,6 +1968,24 @@ class Model(ObjectWithMeta, VarProvider):
                 yield Equation(
                     myokit.Name(var), myokit.Number(self._current_state[k]))
         return StateDefIterator(self)
+
+    def is_similar(self, other, check_unames=False):
+        """
+        Returns ``True`` if this model has the same code as the ``other``
+        model.
+
+        If ``check_unames`` is set to ``True``, the method also checks if the
+        defined unique names and unique name prefixes are the same.
+        """
+        if self is other:
+            return True
+        if not isinstance(other, Model):
+            return False
+        if self._reserved_unames != other._reserved_unames:
+            return False
+        if self._reserved_uname_prefixes != other._reserved_uname_prefixes:
+            return False
+        return self.code() == other.code()
 
     def is_valid(self):
         """

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -606,7 +606,9 @@ class VarOwner(ModelPart, VarProvider):
         """
         # Return model part immediatly
         if isinstance(name, ModelPart):
-            return name
+            if name.model() is self._model:
+                return name
+            name = name.qname()
 
         # Find variable
         names = name.split('.')
@@ -1623,7 +1625,9 @@ class Model(ObjectWithMeta, VarProvider):
         """
         # Return model part immediatly
         if isinstance(name, ModelPart):
-            return name
+            if name.model() is self:
+                return name
+            name = name.qname()
 
         # Split name, get different parts
         names = name.split('.')

--- a/myokit/_parsing.py
+++ b/myokit/_parsing.py
@@ -1853,7 +1853,10 @@ def parse_expression_string(string, context=None):
     info = None
     if context is not None:
         info = ParseInfo()
-        info.model = context.model()
+        if isinstance(context, myokit.Model):
+            info.model = context
+        else:
+            info.model = context.model()
 
     # Tokenise and parse string to proto expression
     s = Tokenizer(string)

--- a/myokit/_protocol.py
+++ b/myokit/_protocol.py
@@ -41,6 +41,10 @@ class Protocol(object):
     the interval ``[a, b)``. In other words, time ``a`` will be the first time
     it is active and time ``b`` will be the first time after ``a`` at which it
     is not.
+
+    Protocols can be compared with ``==``, which will check if the :meth:`code`
+    for both protocols is the same. Protocols can be serialised with
+    ``pickle``.
     """
     def __init__(self):
         super(Protocol, self).__init__()

--- a/myokit/_unit.py
+++ b/myokit/_unit.py
@@ -544,7 +544,11 @@ class Unit(object):
         Existing entries are overwritten without warning.
         """
         # Overwrite existing entries without warning
-        Unit._preferred_representations[unit] = rep
+        if not isinstance(unit, myokit.Unit):
+            raise ValueError(
+                'Second argument to register_preferred_representation must be'
+                ' a myokit.Unit')
+        Unit._preferred_representations[unit] = str(rep)
 
     def __repr__(self):
         """
@@ -825,7 +829,7 @@ class Quantity(object):
         return self._value
 
     def __hash__(self):
-        return self._str
+        return hash(self._str)
 
     def __mul__(self, other):
         if not isinstance(other, Quantity):

--- a/myokit/_unit.py
+++ b/myokit/_unit.py
@@ -560,8 +560,8 @@ class Unit(object):
         return Unit(list(self._x), self._m + math.log10(other))
 
     def __rtruediv__(self, other):
-        # Evaluates ``other / self``, where other is not a unit when future
-        # division is active.
+        # Evaluates ``other / self``, where other is not a unit, in Python 3
+        # or when future division is active.
 
         return Unit([-a for a in self._x], math.log10(other) - self._m)
 

--- a/myokit/_unit.py
+++ b/myokit/_unit.py
@@ -829,7 +829,7 @@ class Quantity(object):
         return self._value
 
     def __hash__(self):
-        return hash(self._str)
+        return hash(self._value) + hash(self._unit)
 
     def __mul__(self, other):
         if not isinstance(other, Quantity):

--- a/myokit/tests/test_component.py
+++ b/myokit/tests/test_component.py
@@ -265,6 +265,11 @@ class VarOwnerTest(unittest.TestCase):
         self.assertIs(c.get(x), x)
         self.assertIs(x.get(c), c)
 
+        # Test asking for object from another model
+        m2 = m.clone()
+        self.assertIsNot(m2.get(c), c)
+        self.assertIs(m2.get(c), m2.get('c'))
+
         # Test not founds
         self.assertRaises(KeyError, m.get, 'y')
         self.assertRaises(KeyError, m.get, 'c.y')

--- a/myokit/tests/test_component.py
+++ b/myokit/tests/test_component.py
@@ -266,9 +266,8 @@ class VarOwnerTest(unittest.TestCase):
         self.assertIs(x.get(c), c)
 
         # Test asking for object from another model
-        m2 = m.clone()
-        self.assertIsNot(m2.get(c), c)
-        self.assertIs(m2.get(c), m2.get('c'))
+        c2 = m.clone().get('c')
+        self.assertRaisesRegex(ValueError, 'different model', c2.get, x)
 
         # Test not founds
         self.assertRaises(KeyError, m.get, 'y')

--- a/myokit/tests/test_expressions.py
+++ b/myokit/tests/test_expressions.py
@@ -855,6 +855,10 @@ class NameTest(unittest.TestCase):
         # Debug/unofficial options
         self.assertEqual(myokit.Name('a'), myokit.Name('a'))
         self.assertNotEqual(myokit.Name('a'), myokit.Name('A'))
+        # The next ones _should_ be equal: since the components and models are
+        # not what's supposed to go inside a name, it will convert to string
+        # and compare the resulting representations. This is the same as what
+        # would happen if __eq__ was called on an expression wrapping a Name.
         self.assertEqual(myokit.Name(c), myokit.Name(c))
         self.assertEqual(myokit.Name(m), myokit.Name(m.clone()))
 

--- a/myokit/tests/test_expressions.py
+++ b/myokit/tests/test_expressions.py
@@ -175,7 +175,7 @@ class ExpressionTest(unittest.TestCase):
         m2 = m1.clone()
         for v in m1.variables(deep=True):
             e1 = v.rhs()
-            e2 = m2.get(v).rhs()
+            e2 = m2.get(v.qname()).rhs()
             if e1.is_literal():
                 self.assertEqual(e1, e1)
             else:

--- a/myokit/tests/test_expressions.py
+++ b/myokit/tests/test_expressions.py
@@ -8,9 +8,12 @@
 from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 
+import pickle
 import unittest
-import myokit
+
 import numpy as np
+
+import myokit
 
 # Unit testing in Python 2 and 3
 try:
@@ -289,6 +292,19 @@ class ExpressionTest(unittest.TestCase):
         self.assertFalse(pe('1 + 2 + 3').is_conditional())
         self.assertTrue(pe('if(1, 0, 2)').is_conditional())
         self.assertTrue(pe('1 + if(1, 0, 2)').is_conditional())
+
+    def test_pickling_error(self):
+        # Tests pickling of expressions raises an exception
+
+        # Test that the right exception is raised
+        m = myokit.load_model('example')
+        e = m.get('ina.INa').rhs()
+        self.assertRaises(NotImplementedError, pickle.dumps, e)
+
+        # Test that the trick in the exception actually works
+        s = e.code()
+        f = myokit.parse_expression(s, context=m)
+        self.assertEqual(e, f)
 
     def test_pyfunc(self):
         # Test the pyfunc() method.

--- a/myokit/tests/test_expressions.py
+++ b/myokit/tests/test_expressions.py
@@ -168,6 +168,19 @@ class ExpressionTest(unittest.TestCase):
             i.lhs().diff(V0, independent_states=False),
             myokit.PartialDerivative(i.lhs(), V0))
 
+    def test_equal(self):
+        # Test equality checking on general equations
+
+        m1 = myokit.load_model('example')
+        m2 = m1.clone()
+        for v in m1.variables(deep=True):
+            e1 = v.rhs()
+            e2 = m2.get(v).rhs()
+            if e1.is_literal():
+                self.assertEqual(e1, e1)
+            else:
+                self.assertNotEqual(e1, e2)
+
     def test_eval(self):
         # Test :meth:`Expression.eval()`.
 
@@ -536,6 +549,18 @@ class NumberTest(unittest.TestCase):
         self.assertTrue(d.is_number(0))
         self.assertEqual(d.unit(), myokit.units.pF / myokit.units.mV)
 
+    def test_equal(self):
+        # Test equality checking on numbers
+        a = myokit.Number(1)
+        b = myokit.Number(1)
+        c = myokit.Number(2)
+        self.assertEqual(a, b)
+        self.assertEqual(b, a)
+        self.assertNotEqual(a, c)
+        self.assertNotEqual(c, a)
+        self.assertNotEqual(b, c)
+        self.assertNotEqual(c, b)
+
     def test_eval(self):
         # Test evaluation (with single precision).
 
@@ -807,6 +832,32 @@ class NameTest(unittest.TestCase):
         self.assertIsInstance(z, myokit.PartialDerivative)
         self.assertEqual(z.code(), 'diff(str:x, str:y)')
 
+    def test_equal(self):
+        # Test equality checking on names
+
+        # Mini model
+        m = myokit.Model()
+        c = m.add_component('c')
+        x = c.add_variable('x')
+        x.set_rhs(3)
+        y = c.add_variable('y')
+        y.set_rhs(2)
+        y.set_unit(myokit.units.Newton)
+
+        self.assertEqual(myokit.Name(x), myokit.Name(x))
+        self.assertEqual(myokit.Name(y), myokit.Name(y))
+        self.assertNotEqual(myokit.Name(x), myokit.Name(y))
+        self.assertNotEqual(myokit.Name(y), myokit.Name(x))
+        self.assertNotEqual(myokit.Name(x), myokit.Name(m.clone().get('c.x')))
+        self.assertNotEqual(myokit.Name(x), myokit.Name('x'))
+        self.assertNotEqual(myokit.Name(x), myokit.Name('c.x'))
+
+        # Debug/unofficial options
+        self.assertEqual(myokit.Name('a'), myokit.Name('a'))
+        self.assertNotEqual(myokit.Name('a'), myokit.Name('A'))
+        self.assertEqual(myokit.Name(c), myokit.Name(c))
+        self.assertEqual(myokit.Name(m), myokit.Name(m.clone()))
+
     def test_eval_unit(self):
         # Test Name eval_unit.
 
@@ -979,6 +1030,27 @@ class DerivativeTest(unittest.TestCase):
         z = x.diff(y)
         self.assertIsInstance(z, myokit.PartialDerivative)
         self.assertEqual(z.code(), 'diff(dot(str:x), str:y)')
+
+    def test_equal(self):
+        # Test equality checking on derivatives
+
+        # Mini model
+        m = myokit.Model()
+        c = m.add_component('c')
+        x = c.add_variable('x')
+        x.set_rhs(3)
+        y = c.add_variable('y')
+        y.set_rhs(2)
+        y.set_unit(myokit.units.Newton)
+
+        D, N = myokit.Derivative, myokit.Name
+        self.assertEqual(D(N(x)), D(N(x)))
+        self.assertEqual(D(N(y)), D(N(y)))
+        self.assertNotEqual(D(N(x)), D(N(y)))
+        self.assertNotEqual(D(N(y)), D(N(x)))
+        self.assertNotEqual(D(N(x)), D(N(m.clone().get('c.x'))))
+        self.assertNotEqual(D(N(x)), D(N('x')))
+        self.assertNotEqual(D(N(x)), D(N('c.x')))
 
     def test_eval_unit(self):
         # Test Derivative.eval_unit()

--- a/myokit/tests/test_expressions.py
+++ b/myokit/tests/test_expressions.py
@@ -3892,6 +3892,16 @@ class EquationTest(unittest.TestCase):
         # No exception = pass
         hash(myokit.Equation(myokit.Name('x'), myokit.Number('3')))
 
+        # Hash must be consistent during lifetime.
+        m = myokit.Model()
+        c = m.add_component('c')
+        x = c.add_variable('x')
+        x.set_rhs('3 * sqrt(2)')
+        a = hash(x.eq())
+        x.rename('y')
+        b = hash(x.eq())
+        self.assertEqual(a, b)
+
     def test_iter(self):
         # Test iteration over an equation.
         lhs = myokit.Name('x')

--- a/myokit/tests/test_model.py
+++ b/myokit/tests/test_model.py
@@ -603,10 +603,7 @@ class ModelTest(unittest.TestCase):
 
         # Get by variable from another model
         m2 = m.clone()
-        w = m2.get(v)
-        self.assertIsNot(w, v)
-        v2 = m2.get(w)
-        self.assertIs(w, v2)
+        self.assertRaisesRegex(ValueError, 'different model', m2.get, v)
 
         # Get nested
         a = m.get('ina.m.alpha')

--- a/myokit/tests/test_model.py
+++ b/myokit/tests/test_model.py
@@ -286,14 +286,15 @@ class ModelTest(unittest.TestCase):
         m1 = myokit.load_model('example')
         m2 = m1.clone()
         self.assertFalse(m1 is m2)
-        self.assertEqual(m1, m2)
+        self.assertNotEqual(m1, m2)
+        self.assertTrue(m1.is_similar(m2, True))
 
         # Test unames and uname prefixes
         m1.reserve_unique_names('barnard', 'lincoln', 'glasgow')
         m1.reserve_unique_name_prefix('monkey', 'giraffe')
         m1.reserve_unique_name_prefix('ostrich', 'turkey')
         m2 = m1.clone()
-        self.assertEqual(m1, m2)
+        self.assertTrue(m1.is_similar(m2, True))
 
         # Test tokens are not cloned
         self.assertTrue(m1.has_parse_info())
@@ -353,7 +354,7 @@ class ModelTest(unittest.TestCase):
             '13 d = comp1.a\n'
         )
 
-    def test_equals(self):
+    def test_is_similar(self):
         # Check that equality takes both code() and unames into account
 
         # Test without custom reserved names
@@ -361,30 +362,36 @@ class ModelTest(unittest.TestCase):
         m2 = m1.clone()
         self.assertIsInstance(m2, myokit.Model)
         self.assertFalse(m1 is m2)
-        self.assertEqual(m1, m2)
-        self.assertEqual(m1, m1)
+        self.assertNotEqual(m1, m2)
+        self.assertNotEqual(m2, m1)
+        self.assertTrue(m1.is_similar(m2, False))
+        self.assertTrue(m1.is_similar(m2, True))
+        self.assertTrue(m2.is_similar(m1, False))
+        self.assertTrue(m2.is_similar(m1, True))
+        self.assertTrue(m1.is_similar(m1, True))
+        self.assertTrue(m2.is_similar(m2, False))
 
         # Test with none-model
-        self.assertNotEqual(m1, None)
-        self.assertNotEqual(m1, m1.code())
+        self.assertFalse(m1.is_similar(None))
+        self.assertFalse(m1.is_similar(m1.code()))
 
         # Add reserved names
         m1.reserve_unique_names('bertie')
-        self.assertNotEqual(m1, m2)
+        self.assertFalse(m1.is_similar(m2))
         m1.reserve_unique_names('clair')
-        self.assertNotEqual(m1, m2)
+        self.assertFalse(m1.is_similar(m2))
         m2.reserve_unique_names('clair', 'bertie')
-        self.assertEqual(m1, m2)
+        self.assertTrue(m1.is_similar(m2))
 
         # Add reserved name prefixes
         m1.reserve_unique_name_prefix('aa', 'bb')
         m1.reserve_unique_name_prefix('cc', 'dd')
-        self.assertNotEqual(m1, m2)
+        self.assertFalse(m1.is_similar(m2))
         m2.reserve_unique_name_prefix('aa', 'bb')
         m2.reserve_unique_name_prefix('cc', 'ee')
-        self.assertNotEqual(m1, m2)
+        self.assertFalse(m1.is_similar(m2))
         m2.reserve_unique_name_prefix('cc', 'dd')
-        self.assertEqual(m1, m2)
+        self.assertTrue(m1.is_similar(m2))
 
     def test_evaluate_derivatives(self):
         # Test Model.evaluate_derivatives().
@@ -717,13 +724,13 @@ class ModelTest(unittest.TestCase):
         self.assertTrue(m1.has_component('p'))
         self.assertFalse(m1['p'] is ms['p'])
         self.assertEqual(m1['p'].code(), ms['p'].code())
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Import a second time, without renaming
         m1.import_component, ms['p']  # Check errors happen before changes
         m1_unaltered = m1.clone()
         self.assertRaises(myokit.DuplicateName, m1.import_component, ms['p'])
-        self.assertEqual(m1, m1_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
 
         # Import a second time, and rename
         m1.import_component(ms['p'], new_name='p2')
@@ -733,7 +740,7 @@ class ModelTest(unittest.TestCase):
         cs = '\n'.join((ms['p'].code().splitlines())[1:])
         c1 = '\n'.join((m1['p2'].code().splitlines())[1:])
         self.assertEqual(cs, c1)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Import independent component with labels and bindings
         m1.import_component(ms['e'])
@@ -742,7 +749,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(m1['e'].code(), ms['e'].code())
         self.assertEqual(m1.label('this_is_g'), m1.get('e.g'))
         self.assertEqual(m1.binding('time'), m1.get('e.t'))
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Now that it has a time variable, m1 should be valid
         m1.validate()
@@ -755,13 +762,13 @@ class ModelTest(unittest.TestCase):
         self.assertRaisesRegex(
             myokit.InvalidLabelError, 'label "this_is_g"',
             m1.import_component, ms['e'], new_name='dinosaur')
-        self.assertEqual(m1, m1_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
         ms.get('e.t').set_binding('time')
         ms.label('this_is_g').set_label(None)
         self.assertRaisesRegex(
             myokit.InvalidBindingError, 'binding "time"',
             m1.import_component, ms['e'], new_name='hello')
-        self.assertEqual(m1, m1_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
         ms = ms_unaltered.clone()
 
         # Import r, using a custom variable mapping
@@ -775,7 +782,7 @@ class ModelTest(unittest.TestCase):
         cs = '\n'.join((ms['p'].code().splitlines())[4:])
         c1 = '\n'.join((m1['p2'].code().splitlines())[4:])
         self.assertEqual(cs, c1)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Import r, using a label for p.b
         ms.get('p.b').set_label('this_is_b')
@@ -792,7 +799,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(cs, c1)
         ms.get('p.b').set_label(None)
         m1.get('p2.b').set_label(None)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Import r, using a binding for e.h
         ms.get('e.h').set_binding('this_is_h')
@@ -809,7 +816,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(cs, c1)
         ms.get('e.h').set_binding(None)
         m1.get('e.h').set_binding(None)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Import r, using (partial) name mapping
         var_map = {'p.a': 'p2.a'}
@@ -822,74 +829,74 @@ class ModelTest(unittest.TestCase):
         cs = '\n'.join((ms['p'].code().splitlines())[2:])
         c1 = '\n'.join((m1['p2'].code().splitlines())[2:])
         self.assertEqual(cs, c1)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Try and fail to import r without a mapping
         m1_unaltered = m1.clone()
         self.assertRaises(
             myokit.VariableMappingError,
             m1.import_component, ms['q'], new_name='q9')
-        self.assertEqual(m1, m1_unaltered)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # With an invalid mapping
         self.assertRaisesRegex(
             TypeError, 'dict or None',
             m1.import_component, ms['q'], new_name='q9', var_map=[3])
-        self.assertEqual(m1, m1_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
         self.assertRaisesRegex(
             TypeError, 'objects or fully qualified',
             m1.import_component, ms['q'], new_name='q9',
             var_map={'p.a': 123, 'p.b': 'p.b', 'e.h': 'e.h'})
-        self.assertEqual(m1, m1_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
         self.assertRaisesRegex(
             TypeError, 'objects or fully qualified',
             m1.import_component, ms['q'], new_name='q9',
             var_map={345: 'p.a', 'p.b': 'p.b', 'e.h': 'e.h'})
-        self.assertEqual(m1, m1_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'Multiple variables map',
             m1.import_component, ms['q'], new_name='q9',
             var_map={'p.a': 'p.a', 'p.b': 'p.a', 'e.h': 'e.h'})
-        self.assertEqual(m1, m1_unaltered)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # With variables from another model or that don't exist
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'was not found in this model',
             m1.import_component, ms['q'], new_name='q9',
             var_map={'p.a': 'one.two', 'p.b': 'p.b', 'e.h': 'e.h'})
-        self.assertEqual(m1, m1_unaltered)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'was not found in the source model',
             m1.import_component, ms['q'], new_name='q9',
             var_map={'ppp.aaa': 'p.a', 'p.b': 'p.b', 'e.h': 'e.h'})
-        self.assertEqual(m1, m1_unaltered)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         v = myokit.Model('a').add_component('p').add_variable('b')
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'is not part of this model',
             m1.import_component, ms['q'], new_name='q9',
             var_map={'p.a': v, 'p.b': 'p.b'})
-        self.assertEqual(m1, m1_unaltered)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'is not part of the source model',
             m1.import_component, ms['q'], new_name='q9',
             var_map={v: 'p.a', 'p.b': 'p.b', 'e.h': 'e.h'})
-        self.assertEqual(m1, m1_unaltered)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Incomplete mapping
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'cannot be mapped',
             m1.import_component, ms['q'], new_name='q9', var_map={})
-        self.assertEqual(m1, m1_unaltered)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(m1.is_similar(m1_unaltered, True))
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Import something that's not a component
         self.assertRaisesRegex(
@@ -965,7 +972,7 @@ class ModelTest(unittest.TestCase):
 
         # Import q, should be same except for dot() expression
         m1.import_component(ms['q'], var_map=vm, convert_units=True)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
         self.assertIn('q', m1)
         self.assertEqual(len(m1['q']), 2)
         self.assertEqual(m1.get('q.e').code(), ms.get('q.e').code())
@@ -978,7 +985,7 @@ class ModelTest(unittest.TestCase):
 
         # Import r, should be same except for the state's RHS
         m1.import_component(ms['r'], var_map=vm, convert_units=True)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
         self.assertIn('r', m1)
         self.assertEqual(len(m1['r']), 1)
         self.assertIn('f', m1['r'])
@@ -1010,7 +1017,7 @@ class ModelTest(unittest.TestCase):
 
         # Import q, converting p.a and dot(p.c)
         m1.import_component(ms['q'], var_map=vm, convert_units=True)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
         self.assertIn('q', m1)
         self.assertEqual(len(m1['q']), 2)
         self.assertEqual(m1.get('q.d').unit(), ms.get('q.d').unit())
@@ -1049,7 +1056,7 @@ class ModelTest(unittest.TestCase):
 
         # Import q, converting p.a and dot(p.c)
         m1.import_component(ms['q'], var_map=vm, convert_units=True)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
         self.assertIn('q', m1)
         self.assertEqual(len(m1['q']), 2)
         self.assertEqual(m1.get('q.d').unit(), ms.get('q.d').unit())
@@ -1081,7 +1088,7 @@ class ModelTest(unittest.TestCase):
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'time variables',
             m1.import_component, ms['p'], convert_units=True)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Attempt import with incompatible time units 1:
         # Component that uses a dot expression
@@ -1104,7 +1111,7 @@ class ModelTest(unittest.TestCase):
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'time variables',
             m1.import_component, ms['q'], var_map=vm, convert_units=True)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
         # Attempt import with incompatible mapped (space) units
         m1 = myokit.parse_model('''
@@ -1127,7 +1134,7 @@ class ModelTest(unittest.TestCase):
         self.assertRaisesRegex(
             myokit.VariableMappingError, 'Unable to convert',
             m1.import_component, ms['q'], var_map=vm, convert_units=True)
-        self.assertEqual(ms, ms_unaltered)
+        self.assertTrue(ms.is_similar(ms_unaltered, True))
 
     def test_item_at_text_position(self):
         # Test :meth:`Model.item_at_text_position()`.
@@ -1373,8 +1380,9 @@ class ModelTest(unittest.TestCase):
         m_bytes = pickle.dumps(m1)
         m2 = pickle.loads(m_bytes)
         self.assertFalse(m1 is m2)
+        self.assertFalse(m1 == m2)
         self.assertIsInstance(m2, myokit.Model)
-        self.assertEqual(m1, m2)
+        self.assertTrue(m1.is_similar(m2))
 
         # Test unique names and prefixes (see also test_clone)
         m1.reserve_unique_names('barnard', 'lincoln', 'glasgow')
@@ -1382,7 +1390,7 @@ class ModelTest(unittest.TestCase):
         m1.reserve_unique_name_prefix('ostrich', 'turkey')
         m_bytes = pickle.dumps(m1)
         m2 = pickle.loads(m_bytes)
-        self.assertEqual(m1, m2)
+        self.assertTrue(m1.is_similar(m2, True))
 
     def test_remove_component(self):
         # Test the removal of a component.

--- a/myokit/tests/test_model.py
+++ b/myokit/tests/test_model.py
@@ -601,6 +601,13 @@ class ModelTest(unittest.TestCase):
         w = m.get(v)
         self.assertIs(w, v)
 
+        # Get by variable from another model
+        m2 = m.clone()
+        w = m2.get(v)
+        self.assertIsNot(w, v)
+        v2 = m2.get(w)
+        self.assertIs(w, v2)
+
         # Get nested
         a = m.get('ina.m.alpha')
         self.assertEqual(a.qname(), 'ina.m.alpha')

--- a/myokit/tests/test_quantity.py
+++ b/myokit/tests/test_quantity.py
@@ -116,17 +116,17 @@ class QuantityTest(unittest.TestCase):
         # Test has does not change in quantity's lifetime
 
         try:
-            u1 = myokit.Quantity(1, myokit.units.m**8)
-            h1 = hash(u1)
-            myokit.Unit.register_preferred_representation(
-                'abc', myokit.units.m**8)
-            u2 = myokit.Quantity(1, myokit.units.m**8)
-            h2 = hash(u2)
+            u = myokit.units.m**8
+            q1 = myokit.Quantity(1, u)
+            h1 = hash(q1)
+            myokit.Unit.register_preferred_representation('abc', u)
+            q2 = myokit.Quantity(1, u)
+            h2 = hash(q2)
             self.assertEqual(h1, h2)
         finally:
             # Bypassing the public API, this is bad test design!
-            if u1 in myokit.Unit._preferred_representations:
-                del(myokit.Unit._preferred_representations[u1])
+            if u in myokit.Unit._preferred_representations:
+                del(myokit.Unit._preferred_representations[u])
 
     def test_number_conversion(self):
         # Test Quantity conversion from and to number.

--- a/myokit/tests/test_quantity.py
+++ b/myokit/tests/test_quantity.py
@@ -24,6 +24,36 @@ class QuantityTest(unittest.TestCase):
     Tests the Quantity class for unit arithmetic.
     """
 
+    def test_as_rhs(self):
+        # Test Quantity use in set_rhs.
+        from myokit import Quantity as Q
+
+        m = myokit.Model()
+        c = m.add_component('a')
+        v = c.add_variable('v')
+        a = Q('10 [mV]')
+        v.set_rhs(a)
+        self.assertEqual(v.rhs().unit(), myokit.units.mV)
+        self.assertEqual(v.eval(), 10)
+
+    def test_cast(self):
+        # Test :meth:`Quanity.cast()`.
+
+        from myokit import Quantity as Q
+
+        a = Q('10 [uA]')
+        b = a.cast('mV')
+        self.assertEqual(a, Q('10 [uA]'))
+        self.assertEqual(b, Q('10 [mV]'))
+
+    def test_convert(self):
+        # Test :meth:`Quantity.convert()`.
+
+        from myokit import Quantity as Q
+
+        a = Q('10 [mV]')
+        self.assertEqual(a.convert('V'), Q('0.01 [V]'))
+
     def test_creation_and_str(self):
         # Test Quanity creation and :meth:`Quantity.__str__()`.
 
@@ -71,6 +101,20 @@ class QuantityTest(unittest.TestCase):
         # Test hash
         self.assertEqual(str(x), x.__hash__())
 
+    def test_eq(self):
+        # Test :meth:`Quantity.__eq__()`.
+        from myokit import Quantity as Q
+
+        a = Q('10 [mV]')
+        self.assertEqual(a, Q('10 [mV]'))
+        self.assertNotEqual(a, Q('11 [mV]'))
+        self.assertNotEqual(a, Q('10 [mA]'))
+        self.assertNotEqual(a, Q('10 [V]'))
+        self.assertNotEqual(a, Q('0.01 [V]'))
+        self.assertEqual(a, Q('0.01 [V]').convert('mV'))
+        self.assertFalse(Q(4) == 4)
+        self.assertFalse(4 == Q(4))
+
     def test_number_conversion(self):
         # Test Quantity conversion from and to number.
 
@@ -91,40 +135,6 @@ class QuantityTest(unittest.TestCase):
         b = myokit.Number(a)
         self.assertEqual(b.eval(), 10)
         self.assertEqual(b.unit(), myokit.units.mV)
-
-    def test_as_rhs(self):
-        # Test Quantity use in set_rhs.
-        from myokit import Quantity as Q
-
-        m = myokit.Model()
-        c = m.add_component('a')
-        v = c.add_variable('v')
-        a = Q('10 [mV]')
-        v.set_rhs(a)
-        self.assertEqual(v.rhs().unit(), myokit.units.mV)
-        self.assertEqual(v.eval(), 10)
-
-    def test_eq(self):
-        # Test :meth:`Quantity.__eq__()`.
-        from myokit import Quantity as Q
-
-        a = Q('10 [mV]')
-        self.assertEqual(a, Q('10 [mV]'))
-        self.assertNotEqual(a, Q('11 [mV]'))
-        self.assertNotEqual(a, Q('10 [mA]'))
-        self.assertNotEqual(a, Q('10 [V]'))
-        self.assertNotEqual(a, Q('0.01 [V]'))
-        self.assertEqual(a, Q('0.01 [V]').convert('mV'))
-        self.assertFalse(Q(4) == 4)
-        self.assertFalse(4 == Q(4))
-
-    def test_convert(self):
-        # Test :meth:`Quantity.convert()`.
-
-        from myokit import Quantity as Q
-
-        a = Q('10 [mV]')
-        self.assertEqual(a.convert('V'), Q('0.01 [V]'))
 
     def test_operators(self):
         # Test overloaded operators for Quantity.
@@ -212,15 +222,6 @@ class QuantityTest(unittest.TestCase):
         with self.assertRaises(myokit.IncompatibleUnitError):
             a ** a
 
-    def test_cast(self):
-        # Test :meth:`Quanity.cast()`.
-
-        from myokit import Quantity as Q
-
-        a = Q('10 [uA]')
-        b = a.cast('mV')
-        self.assertEqual(a, Q('10 [uA]'))
-        self.assertEqual(b, Q('10 [mV]'))
 
 
 if __name__ == '__main__':

--- a/myokit/tests/test_quantity.py
+++ b/myokit/tests/test_quantity.py
@@ -125,8 +125,8 @@ class QuantityTest(unittest.TestCase):
             self.assertEqual(h1, h2)
         finally:
             # Bypassing the public API, this is bad test design!
-            if 'abc' in myokit.Unit._preferred_representations:
-                del(myokit.Unit._preferred_representations['abc'])
+            if u1 in myokit.Unit._preferred_representations:
+                del(myokit.Unit._preferred_representations[u1])
 
     def test_number_conversion(self):
         # Test Quantity conversion from and to number.

--- a/myokit/tests/test_quantity.py
+++ b/myokit/tests/test_quantity.py
@@ -115,12 +115,18 @@ class QuantityTest(unittest.TestCase):
     def test_hash(self):
         # Test has does not change in quantity's lifetime
 
-        u1 = myokit.Quantity(1, myokit.units.m**8)
-        h1 = hash(u1)
-        myokit.Unit.register_preferred_representation('abc', myokit.units.m**8)
-        u2 = myokit.Quantity(1, myokit.units.m**8)
-        h2 = hash(u2)
-        self.assertEqual(h1, h2)
+        try:
+            u1 = myokit.Quantity(1, myokit.units.m**8)
+            h1 = hash(u1)
+            myokit.Unit.register_preferred_representation(
+                'abc', myokit.units.m**8)
+            u2 = myokit.Quantity(1, myokit.units.m**8)
+            h2 = hash(u2)
+            self.assertEqual(h1, h2)
+        finally:
+            # Bypassing the public API, this is bad test design!
+            if 'abc' in myokit.Unit._preferred_representations:
+                del(myokit.Unit._preferred_representations['abc'])
 
     def test_number_conversion(self):
         # Test Quantity conversion from and to number.
@@ -228,7 +234,6 @@ class QuantityTest(unittest.TestCase):
         self.assertAlmostEqual(b.value(), 10)
         with self.assertRaises(myokit.IncompatibleUnitError):
             a ** a
-
 
 
 if __name__ == '__main__':

--- a/myokit/tests/test_quantity.py
+++ b/myokit/tests/test_quantity.py
@@ -98,9 +98,6 @@ class QuantityTest(unittest.TestCase):
         self.assertRaisesRegex(
             ValueError, 'Two units', myokit.Quantity, '2 [mV]', 'mV')
 
-        # Test hash
-        self.assertEqual(str(x), x.__hash__())
-
     def test_eq(self):
         # Test :meth:`Quantity.__eq__()`.
         from myokit import Quantity as Q
@@ -114,6 +111,16 @@ class QuantityTest(unittest.TestCase):
         self.assertEqual(a, Q('0.01 [V]').convert('mV'))
         self.assertFalse(Q(4) == 4)
         self.assertFalse(4 == Q(4))
+
+    def test_hash(self):
+        # Test has does not change in quantity's lifetime
+
+        u1 = myokit.Quantity(1, myokit.units.m**8)
+        h1 = hash(u1)
+        myokit.Unit.register_preferred_representation('abc', myokit.units.m**8)
+        u2 = myokit.Quantity(1, myokit.units.m**8)
+        h2 = hash(u2)
+        self.assertEqual(h1, h2)
 
     def test_number_conversion(self):
         # Test Quantity conversion from and to number.

--- a/myokit/tests/test_unit.py
+++ b/myokit/tests/test_unit.py
@@ -314,8 +314,14 @@ class MyokitUnitTest(unittest.TestCase):
 
         u = myokit.units.m**8
         self.assertEqual(str(u), '[m^8]')
-        myokit.Unit.register_preferred_representation('abc', myokit.units.m**8)
-        self.assertEqual(str(u), '[abc]')
+        try:
+            myokit.Unit.register_preferred_representation(
+                'abc', myokit.units.m**8)
+            self.assertEqual(str(u), '[abc]')
+        finally:
+            # Bypassing the public API, this is bad test design!
+            if 'abc' in myokit.Unit._preferred_representations:
+                del(myokit.Unit._preferred_representations['abc'])
 
     def test_str(self):
         # Test :meth:`Unit.str()`

--- a/myokit/tests/test_unit.py
+++ b/myokit/tests/test_unit.py
@@ -309,6 +309,14 @@ class MyokitUnitTest(unittest.TestCase):
         self.assertRaises(TypeError, myokit.Unit.register, 4, myokit.Unit())
         self.assertRaises(TypeError, myokit.Unit.register, 'hi', 4)
 
+    def test_register_preferred_representation(self):
+        # Test new representations can be registered
+
+        u = myokit.units.m**8
+        self.assertEqual(str(u), '[m^8]')
+        myokit.Unit.register_preferred_representation('abc', myokit.units.m**8)
+        self.assertEqual(str(u), '[abc]')
+
     def test_str(self):
         # Test :meth:`Unit.str()`
 

--- a/myokit/tests/test_unit.py
+++ b/myokit/tests/test_unit.py
@@ -320,8 +320,8 @@ class MyokitUnitTest(unittest.TestCase):
             self.assertEqual(str(u), '[abc]')
         finally:
             # Bypassing the public API, this is bad test design!
-            if 'abc' in myokit.Unit._preferred_representations:
-                del(myokit.Unit._preferred_representations['abc'])
+            if u in myokit.Unit._preferred_representations:
+                del(myokit.Unit._preferred_representations[u])
 
     def test_str(self):
         # Test :meth:`Unit.str()`

--- a/myokit/tests/test_unit.py
+++ b/myokit/tests/test_unit.py
@@ -318,6 +318,11 @@ class MyokitUnitTest(unittest.TestCase):
             myokit.Unit.register_preferred_representation(
                 'abc', myokit.units.m**8)
             self.assertEqual(str(u), '[abc]')
+
+            self.assertRaisesRegex(
+                ValueError, 'must be a myokit.Unit',
+                myokit.Unit.register_preferred_representation, 'x', 123)
+
         finally:
             # Bypassing the public API, this is bad test design!
             if u in myokit.Unit._preferred_representations:

--- a/myokit/tests/test_variable.py
+++ b/myokit/tests/test_variable.py
@@ -592,20 +592,20 @@ class VariableTest(unittest.TestCase):
 
         # Remove children on var without children
         m.get('z.a').remove_child_variables()
-        self.assertEqual(m, m_org)
+        self.assertTrue(m.is_similar(m_org, True))
 
         # Remove children on var with used children
         self.assertRaisesRegex(
             myokit.IntegrityError, 'the RHS still depends on <z.e.f>.',
             m.get('z.e').remove_child_variables)
-        self.assertEqual(m, m_org)
+        self.assertTrue(m.is_similar(m_org, True))
 
         # Remove children on nested var with used children
         self.assertRaisesRegex(
             myokit.IntegrityError,
             'depends on <z.e.f.h.[i|j]> and <z.e.f.h.[j|i]>.',
             m.get('z.e.f.h').remove_child_variables)
-        self.assertEqual(m, m_org)
+        self.assertTrue(m.is_similar(m_org, True))
 
         # Remove children on nested var with unused children
         e = m.get('z.e')


### PR DESCRIPTION
See #842 

- Pickling an expression now raises an error which suggests an alternative way to serialise expressions.
- myokit.parse_expression() now accepts a model as a context.
- model comparison with `==` is now back to the default `is` implementation. The old `==` overload is available as `Model.is_similar`
- Model.get() and Component.get() raise errors if objects from a different model are passed in
- Hashes for equation and quantity were fixed, equations are now immutable.