### PR TITLE
Added line_args and fill_args arguments to cumulative_current().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This page lists the main changes made to Myokit in each release.
 
 ## Unreleased
 - Added
+  - [#866](https://github.com/MichaelClerx/myokit/pull/866) The method `myokit.lib.plots.cumulative_current` now takes two arguments `line_args` and `fill_args` that can be used to customize the plotting style.
 - Changed
   - [#865](https://github.com/MichaelClerx/myokit/pull/865) Added more platform information to `myokit system`.
 - Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ This page lists the main changes made to Myokit in each release.
 
 ## Unreleased
 - Added
-  - [#866](https://github.com/MichaelClerx/myokit/pull/866) The method `myokit.lib.plots.cumulative_current` now takes two arguments `line_args` and `fill_args` that can be used to customize the plotting style.
 - Changed
   - [#865](https://github.com/MichaelClerx/myokit/pull/865) Added more platform information to `myokit system`.
+  - [#866](https://github.com/MichaelClerx/myokit/pull/866) Slightly tweaked the plotting in `myokit.lib.plots.cumulative_current`, and added two arguments `line_args` and `fill_args` that can be used to customize the plotting style.
 - Deprecated
 - Removed
 - Fixed

--- a/myokit/lib/plots.py
+++ b/myokit/lib/plots.py
@@ -265,7 +265,7 @@ def current_arrows(log, voltage, currents, axes=None):
 
 def cumulative_current(
         log, currents, axes=None, labels=None, colors=None, integrate=False,
-        normalise=False, max_currents=None):
+        normalise=False, max_currents=None, line_args={}, fill_args={}):
     """
     Plots a number of currents, one on top of the other, with the positive and
     negative parts of the current plotted separately.
@@ -297,6 +297,11 @@ def cumulative_current(
     ``max_currents``
         Set this to any integer n to display only the first n currents, and
         group the rest together in a remainder current.
+    ``line_args``
+        An optional dict with keyword arguments to pass in when drawing lines.
+    ``fill_args``
+        An optional dict with keyword arguments to pass in when drawing shaded
+        areas.
 
     The best results are obtained if relatively constant currents are specified
     early. Another rule of thumb is to specify the currents roughly in the
@@ -348,6 +353,12 @@ def cumulative_current(
         cmap = matplotlib.cm.get_cmap(name='tab20')
         colors = [cmap(i) for i in range(nc)]
 
+    # Line drawing keyword arguments
+    if 'color' not in line_args:
+        line_args['color'] = 'k'
+    if 'lw' not in line_args:
+        line_args['lw'] = 1
+
     # Plot
     op = on = 0
     for k in range(nc):
@@ -378,10 +389,10 @@ def cumulative_current(
             p, n = op + pos[k], on + neg[k]
 
         # Plot!
-        axes.fill_between(t, p, op, facecolor=color)
-        axes.fill_between(t, n, on, facecolor=color)
-        axes.plot(t, p, color=color, label=label)
-        axes.plot(t, p, color='k', lw=1)
-        axes.plot(t, n, color='k', lw=1)
+        axes.plot(t, p, color=color, label=label, zorder=-1, lw=0)
+        axes.fill_between(t, p, op, facecolor=color, **fill_args)
+        axes.fill_between(t, n, on, facecolor=color, **fill_args)
+        axes.plot(t, p, **line_args)
+        axes.plot(t, n, **line_args)
         on = n
         op = p

--- a/myokit/lib/plots.py
+++ b/myokit/lib/plots.py
@@ -389,7 +389,7 @@ def cumulative_current(
             p, n = op + pos[k], on + neg[k]
 
         # Plot!
-        axes.fill_between(t, p, op, facecolor=color, **fill_args, label=label)
+        axes.fill_between(t, p, op, facecolor=color, label=label, **fill_args)
         axes.fill_between(t, n, on, facecolor=color, **fill_args)
         axes.plot(t, p, **line_args)
         axes.plot(t, n, **line_args)

--- a/myokit/lib/plots.py
+++ b/myokit/lib/plots.py
@@ -389,8 +389,7 @@ def cumulative_current(
             p, n = op + pos[k], on + neg[k]
 
         # Plot!
-        axes.plot(t, p, color=color, label=label, zorder=-1, lw=3)
-        axes.fill_between(t, p, op, facecolor=color, **fill_args)
+        axes.fill_between(t, p, op, facecolor=color, **fill_args, label=label)
         axes.fill_between(t, n, on, facecolor=color, **fill_args)
         axes.plot(t, p, **line_args)
         axes.plot(t, n, **line_args)

--- a/myokit/lib/plots.py
+++ b/myokit/lib/plots.py
@@ -389,7 +389,7 @@ def cumulative_current(
             p, n = op + pos[k], on + neg[k]
 
         # Plot!
-        axes.plot(t, p, color=color, label=label, zorder=-1, lw=0)
+        axes.plot(t, p, color=color, label=label, zorder=-1, lw=3)
         axes.fill_between(t, p, op, facecolor=color, **fill_args)
         axes.fill_between(t, n, on, facecolor=color, **fill_args)
         axes.plot(t, p, **line_args)


### PR DESCRIPTION
Slightly tweaked the plotting in `myokit.lib.plots.cumulative_current`, and added two arguments `line_args` and `fill_args` that can be used to customize the plotting style.