### PR TITLE
Memory leak when using `log_times`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This page lists the main changes made to Myokit in each release.
 - Deprecated
 - Removed
 - Fixed
+  - [#883](https://github.com/MichaelClerx/myokit/pull/883) Fixed memory leak in `myokit.Simulation` when using the `log_times` argument.
 
 ## [1.33.6] - 2022-07-04
 - Added

--- a/myokit/tests/memory/memleak.py
+++ b/myokit/tests/memory/memleak.py
@@ -93,6 +93,7 @@ sens2 = (m.states(), sens2)
 lt = np.linspace(0, 20, 1000)
 c = 0
 #c += test(myokit.Simulation, m, p, repeats=300, duration=20)
+#c += test(myokit.Simulation, m, p, repeats=300, duration=20, log=True)
 c += test(myokit.Simulation, m, p, repeats=300, duration=20, log=True, log_times=lt)  # noqa
 #c += test(myokit.Simulation, m, p, sens, name='Sensitivities 1')
 #c += test(myokit.Simulation, m, p, sens2, duration=1, name='Sensitivities 2')


### PR DESCRIPTION
Only in cvodessim, not in cvode sim.
Introduced when switching from list to sequence interface for `log_times` handling

![log_times](https://user-images.githubusercontent.com/517644/181242372-f40994d5-22c5-4b5f-b802-5d336eb64c69.png)
