### PR TITLE
feat(diffsl): allow explicit time dependence

### DIFF
--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -241,7 +241,6 @@ class DiffSLExporter(myokit.formats.Exporter):
         # State derivatives are handled in F_i; time is excluded from the
         # output; pace is handled separately; inputs are in the in block.
         time = model.time()
-        self._var_to_name[time] = 't'  # DiffSL built-in time variable
         pace = model.binding('pace')
         special_vars = set(v for v in model.states())
         special_vars.add(time)
@@ -442,6 +441,9 @@ class DiffSLExporter(myokit.formats.Exporter):
             return ''.join(name_chars)
 
         var_to_name = collections.OrderedDict()
+        
+        time = model.time()
+        self._var_to_name[time] = 't'  # DiffSL built-in time variable
 
         # Store initial names for variables
         for var in model.variables(deep=True, sort=True):

--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -441,9 +441,6 @@ class DiffSLExporter(myokit.formats.Exporter):
             return ''.join(name_chars)
 
         var_to_name = collections.OrderedDict()
-        
-        time = model.time()
-        self._var_to_name[time] = 't'  # DiffSL built-in time variable
 
         # Store initial names for variables
         for var in model.variables(deep=True, sort=True):
@@ -487,6 +484,9 @@ class DiffSLExporter(myokit.formats.Exporter):
                     name = f'{root}{i}'
                 var_to_name[var] = name
                 name_to_var[name] = var
+
+        time = model.time()
+        var_to_name[time] = 't'  # DiffSL built-in time variable
 
         return var_to_name
 

--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -85,8 +85,8 @@ class DiffSLExporter(myokit.formats.Exporter):
                         f'Input variable {v.qname()} does not belong to the '
                         f'model being exported.'
                     )
-                # Validate that inputs are constants
-                if not v.is_constant():
+                # Validate that inputs are constants (pace binding is allowed)
+                if not v.is_constant() and v.binding() != 'pace':
                     raise myokit.ExportError(
                         f'Input variable {v.qname()} must be a constant.'
                     )
@@ -276,8 +276,8 @@ class DiffSLExporter(myokit.formats.Exporter):
             export_lines.append('in_i { }')
         export_lines.append('')
 
-        # Add pace
-        if pace is not None:
+        # Add pace (skipped if pace is provided as an explicit input)
+        if pace is not None and pace not in inputs:
             export_lines.append('/* Engine: pace */')
             export_lines.append('/* E.g.')
             export_lines.append('  -80 * (1 - sigmoid((t-100)*5000))')

--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -169,14 +169,6 @@ class DiffSLExporter(myokit.formats.Exporter):
         cm = guess.membrane_capacitance(model)  # Cm
         currents = self._guess_currents(model)
 
-        # Check for explicit time dependence
-        time_refs = list(time.refs_by())
-        if time_refs:
-            raise myokit.ExportError(
-                'DiffSL export does not support explicit time dependence:\n'
-                + '\n'.join([f'{v} = {v.rhs()}' for v in time_refs])
-            )
-
         if convert_units:
             # Convert currents to A/F
             helpers = [] if cm is None else [cm.rhs()]
@@ -249,6 +241,7 @@ class DiffSLExporter(myokit.formats.Exporter):
         # State derivatives are handled in F_i; time is excluded from the
         # output; pace is handled separately; inputs are in the in block.
         time = model.time()
+        self._var_to_name[time] = 't'  # DiffSL built-in time variable
         pace = model.binding('pace')
         special_vars = set(v for v in model.states())
         special_vars.add(time)

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -176,16 +176,31 @@ class DiffSLExporterTest(unittest.TestCase):
             v.set_rhs(3)
             e.model(path, model)
 
-            # Test with explicit time dependence
-            t0 = model.get('membrane').add_variable('t0')
-            t0.set_rhs('0 + engine.time')
-            with self.assertRaisesRegex(myokit.ExportError, 'time dependence'):
-                e.model(path, model)
-
             # Test with invalid model
             v.set_rhs('2 * V')
             with self.assertRaisesRegex(myokit.ExportError, 'valid model'):
                 e.model(path, model)
+
+    def test_explicit_time_dependence(self):
+        # Tests that explicit time dependence (dot(y) = -y * t) is supported
+        m_td = myokit.parse_model("""
+[[model]]
+c.y = 1.0
+
+[engine]
+time = 0
+    bind time
+
+[c]
+dot(y) = -y * engine.time
+""")
+        e = myokit.formats.diffsl.DiffSLExporter()
+        with TemporaryDirectory() as d:
+            path = d.path('diffsl.model')
+            e.model(path, m_td)
+            with open(path) as f:
+                content = f.read()
+        self.assertRegex(content, r'F_i\s*\{\s*-cY\s*\*\s*t,\s*\}')
 
     def test_unit_conversion(self):
         # Tests exporting a model that requires unit conversion

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -347,6 +347,18 @@ dot(y) = -y * engine.time
                 out_content.index('membraneV'), out_content.index('inaM')
             )
 
+            # Test with engine.pace as an input
+            path = d.path('test_pace_input.diffsl')
+            e.model(path, model, inputs=[model.get('engine.pace')])
+            with open(path, 'r') as f:
+                content = f.read()
+            # pace should appear in in_i block
+            match = re.search(r'in_i\s*\{([^}]*)\}', content, re.DOTALL)
+            self.assertIsNotNone(match)
+            self.assertIn('enginePace', match.group(1))
+            # pace should not also appear in a separate variable block
+            self.assertNotIn('/* Engine: pace */', content)
+
     def test_inputs_outputs_validation(self):
         # Tests validation of inputs and outputs parameters
 


### PR DESCRIPTION
fixes #1189

removes explit time dependence check and error, adds a test to check that time is handled correctly

update (13/3/26): also allow pacing variables to be in the list of inputs