### PR TITLE
Allow myokit.step() to specify inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This page lists the main changes made to Myokit in each release.
 - Changed
   - [#1188](https://github.com/myokit/myokit/pull/1188) Updated syntax used in DiffSL exporter, and added option to manually specify inputs and outputs.
   - [#1194](https://github.com/myokit/myokit/pull/1194) Updated the CellML exporter and CellML 1 exporter to use version 1.1 by default (replacing 1.0).
+  - [#1195](https://github.com/myokit/myokit/pull/1195) The method `myokit.step` now takes an argument `state` instead of `initial`, and has a new argument `inputs` that allows values of bound variables to be supplied.
+  - [#1195](https://github.com/myokit/myokit/pull/1195) The method `Model.evaluate_derivatives` will now raise an exception if unknown inputs are specified and the new argument `ignore_unbound_inputs` is set to True. 
 - Deprecated
 - Removed
 - Fixed

--- a/myokit/_aux.py
+++ b/myokit/_aux.py
@@ -569,14 +569,16 @@ def run(model, protocol, script, stdout=None, stderr=None, progress=None):
     gc.collect()
 
 
-def step(model, initial=None, reference=None, ignore_errors=False):
+def step(model, state=None, inputs=None, reference=None, ignore_errors=False):
     """
     Evaluates the state derivatives in a model and compares the results with a
     list of reference values, if given.
 
     The ``model`` should be given as a valid :class:`myokit.Model`. The state
-    values to start from can be given as ``initial``, which should be any item
-    that can be converted to a valid state using ``model.map_to_state``.
+    values to start from can be given as ``state``, which should be any item
+    that can be converted to a valid state using ``model.map_to_state``. An
+    optional dictionary mapping binding labels to values can be given as
+    ``inputs``.
 
     The values can be compared to reference output given as a list
     ``reference``. Alternatively, if ``reference`` is a model the two models'
@@ -589,16 +591,16 @@ def step(model, initial=None, reference=None, ignore_errors=False):
     Returns a string indicating the results.
     """
     # Get initial state
-    if initial is None:
-        initial = model.initial_values(as_floats=True)
+    if state is None:
+        state = model.initial_values(as_floats=True)
     else:
         # Convert initial values etc to floats. Will also be performed by
         # evaluate_derivatives, but done here for the printing code below.
-        initial = model.map_to_state(initial)
+        state = model.map_to_state(state)
 
     # Get evaluation at initial state
     values = model.evaluate_derivatives(
-        state=initial, ignore_errors=ignore_errors)
+        state=state, inputs=inputs, ignore_errors=ignore_errors)
 
     # Log settings
     fmat = myokit.SFDOUBLE
@@ -621,14 +623,14 @@ def step(model, initial=None, reference=None, ignore_errors=False):
     if not reference:
         # Default output: intial value and derivative
         for r, v in enumerate(model.states()):
-            log.append(f.format(v.qname(), initial[r], values[r]))
+            log.append(f.format(v.qname(), state[r], values[r]))
     else:
         # Comparing output
 
         # Reference should be a state evaluation, or a model
         if isinstance(reference, myokit.Model):
             reference = reference.evaluate_derivatives(
-                state=initial, ignore_errors=ignore_errors)
+                state=state, inputs=inputs, ignore_errors=ignore_errors)
 
         h = ' ' * (w + 28)
         i = h + ' ' * 20
@@ -639,7 +641,7 @@ def step(model, initial=None, reference=None, ignore_errors=False):
         for r, v in enumerate(model.states()):
             x = values[r]
             y = reference[r]
-            log.append(f.format(v.qname(), initial[r], x))
+            log.append(f.format(v.qname(), state[r], x))
             xx = fmat.format(x)
             yy = fmat.format(y)
             line = g.format(y)

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -996,8 +996,7 @@ class Model(ObjectWithMetaData, VarProvider):
             return self._bindings[binding]
         except KeyError:
             raise myokit.IncompatibleModelError(
-                self.name(),
-                'No variable found with binding "' + str(binding) + '".')
+                self.name(), f'No variable found with binding "{binding}".')
 
     def check_units(self, mode=myokit.UNIT_TOLERANT):
         """
@@ -1353,7 +1352,7 @@ class Model(ObjectWithMetaData, VarProvider):
 
     def evaluate_derivatives(
             self, state=None, inputs=None, precision=myokit.DOUBLE_PRECISION,
-            ignore_errors=False):
+            ignore_errors=False, ignore_unbound_inputs=True):
         """
         Evaluates and returns the values of all state variable derivatives.
         The values are returned in a list sorted in the same order as the
@@ -1367,15 +1366,23 @@ class Model(ObjectWithMetaData, VarProvider):
             by :meth:``map_to_state()``.
         ``inputs=None``
             To set the values of external inputs, a dictionary mapping binding
-            labels to values can be passed in as ``inputs``.
+            labels to values can be passed in as ``inputs``. Inputs for
+            bindings not present in the model are silently ignored unless
+            ``ignore_unbound_inputs=False``.
         ``precision``
             To assist in finding the origins of numerical errors, the equations
             can be evaluated using single-precision floating point. To do this,
             set ``precision=myokit.SINGLE_PRECISION``.
-        ``ignore_errors``
+        ``ignore_errors=False``
             By default, the evaluation routine raises
             :class:`myokit.NumericalError` exceptions for invalid operations.
-            To return ``NaN`` instead, set ``ignore_errors=True``.
+            To return vector containing ``nan``s instead, set
+            ``ignore_errors=True``.
+        ``ignore_unbound_inputs=True``
+            By default, bindings specified in ``inputs`` but not set in the
+            model are silently ignored. To raise a
+            :class:`IncompatibleModelError` instead (see :meth:`bindingx`) set
+            ``ignore_unbound_inputs=False``.
 
         """
         values = {}
@@ -1393,6 +1400,10 @@ class Model(ObjectWithMetaData, VarProvider):
                 var = self._bindings.get(label)
                 if var is not None:
                     values[myokit.Name(var)] = float(value)
+                elif not ignore_unbound_inputs:
+                    raise myokit.IncompatibleModelError(
+                        self.name(),
+                        f'No variable found with binding "{label}".')
 
         # Get solvable order
         order = self.solvable_order()

--- a/myokit/_sim/openclsim.py
+++ b/myokit/_sim/openclsim.py
@@ -502,7 +502,9 @@ class SimulationOpenCL(myokit.CModule):
                         ifirst = bisect(ar, 0, ifirst)
                         if ifirst == 0:
                             break
-                return ifirst, kfirst
+                # Oddly, this line (but not the ones above) is sometimes listed
+                # as missed by cover testing:
+                return ifirst, kfirst   # pragma: no cover
 
         else:
 

--- a/myokit/tests/test_aux.py
+++ b/myokit/tests/test_aux.py
@@ -343,7 +343,7 @@ class AuxTest(unittest.TestCase):
         # For whatever reason, CI gives slightly different final 3 digits some
         # times.
         state = [-80, 1e-7, 0.1, 0.9, 0.9, 0.1, 0.9, 0.1]
-        x = myokit.step(m1, initial=state).splitlines()
+        x = myokit.step(m1, state=state).splitlines()
         y = [
             'Evaluating state vector derivatives...',
             '-' * 79,
@@ -403,7 +403,7 @@ class AuxTest(unittest.TestCase):
         self.assertEqual(len(x), len(y))
 
         # Test comparison against another model, with an initial state
-        x = myokit.step(m1, reference=m2, initial=state).splitlines()
+        x = myokit.step(m1, reference=m2, state=state).splitlines()
         y = [
             'Evaluating state vector derivatives...',
             '-' * 79,
@@ -526,9 +526,38 @@ class AuxTest(unittest.TestCase):
             self.assertEqual(a, b)
         self.assertEqual(len(x), len(y))
 
+        # Test setting inputs
+        p = m1.get('c').add_variable('p', rhs=0, binding='pace')
+        m1.get('c.x').set_rhs('3 * c.t')
+        m1.get('c.y').set_rhs('c.p + c.t')
+        x = myokit.step(m1).splitlines()
+        y = [
+            'Evaluating state vector derivatives...',
+            '-' * 79,
+            'Name  Initial value             Derivative at t=0       ',
+            '-' * 79,
+            'c.x    1.00000000000000000e+00   0.00000000000000000e+00',
+            'c.y    1.00000000000000000e+00   0.00000000000000000e+00',
+            '-' * 79,
+        ]
+        for a, b in zip(x, y):
+            self.assertEqual(a, b)
+        self.assertEqual(len(x), len(y))
+        y[4:6] = ['c.x    1.00000000000000000e+00   6.00000000000000000e+00',
+                  'c.y    1.00000000000000000e+00   2.50000000000000000e+00']
+        x = myokit.step(m1, inputs={'time': 2, 'pace': 0.5}).splitlines()
+        for a, b in zip(x, y):
+            self.assertEqual(a, b)
+        # Non-existent / unbound are ignored
+        y[4:6] = ['c.x    1.00000000000000000e+00   6.00000000000000000e+00',
+                  'c.y    1.00000000000000000e+00   2.00000000000000000e+00']
+        x = myokit.step(m1, inputs={'time': 2, 'hello': 0.5}).splitlines()
+        for a, b in zip(x, y):
+            self.assertEqual(a, b)
+
         # No issues when passing initial state from a model
         # See https://github.com/myokit/myokit/pull/1083
-        myokit.step(m1, reference=m2, initial=m1.initial_values())
+        myokit.step(m1, reference=m2, state=m1.initial_values())
 
     def test_strfloat(self):
         # Deprecated alias of myokit.float.str

--- a/myokit/tests/test_model.py
+++ b/myokit/tests/test_model.py
@@ -497,6 +497,16 @@ class ModelTest(unittest.TestCase):
             model.evaluate_derivatives(inputs={'pace': 10, 'time': 20}),
             [1, 4, 40])
 
+        # Unknown inputs
+        self.assertIsNone(model.binding('hello'))
+        self.assertEqual(
+            model.evaluate_derivatives(inputs={'pace': 10, 'hello': 12}),
+            [1, 4, 21])
+        self.assertRaisesRegex(
+            myokit.IncompatibleModelError, 'binding "hello"',
+            model.evaluate_derivatives, inputs={'hello': 12},
+            ignore_unbound_inputs=False)
+
         # Deprecated name
         with WarningCollector() as w:
             self.assertEqual(


### PR DESCRIPTION
Multiple small things:

1. Allow myokit.step() to provide inputs, like evaluate_derivatives does
2. Add option to check all bindings in inputs exists to evaluate_derivatives
3. Set default CellML 1 version to 1.1 in exporter, not 1.0

To-do: tests and changelog updates