### PR TITLE
feat(diffsl export): support pacing protocols using diffsl hybrid models

### DIFF
--- a/docs/source/api_formats/diffsl.rst
+++ b/docs/source/api_formats/diffsl.rst
@@ -4,7 +4,24 @@
 DiffSL
 ******
 
-Myokit provides partial export of models to the `DiffSL language <https://martinjrobins.github.io/diffsl/>`_.
+Myokit provides export of models to the `DiffSL language <https://martinjrobins.github.io/diffsl/>`_.
+
+**Model-only export** produces a standard DiffSL ODE in ``u_i``/``F_i``/``out_i`` form.
+
+**Protocol export** generates a *hybrid* ODE model using DiffSL's ``N`` and
+``stop`` constructs, matching the dosing-schedule pattern
+described in the `DiffSL hybrid ODE documentation <https://martinjrobins.github.io/diffsl/odes.html>`_.
+
+Protocol events are expanded to an explicit list of one-off boundary transitions:
+
+* A ``pace_i`` vector holds the pace level for each model phase indexed by ``N``.
+* A ``stop_i`` vector encodes each transition time; stop element ``k`` crosses
+  zero at time ``t_{k+1}``, triggering a solver stop and setting ``N = k``.
+State variables are preserved by default at transitions; pace changes are
+communicated through the updated ``N``\→``pace_i[N]`` lookup.
+
+If a protocol is provided, a ``final_time`` must be passed to
+:meth:`DiffSLExporter.model` so expansion is always finite.
 
 Exporters and expression writers
 ================================

--- a/docs/source/api_formats/diffsl.rst
+++ b/docs/source/api_formats/diffsl.rst
@@ -9,19 +9,10 @@ Myokit provides export of models to the `DiffSL language <https://martinjrobins.
 **Model-only export** produces a standard DiffSL ODE in ``u_i``/``F_i``/``out_i`` form.
 
 **Protocol export** generates a *hybrid* ODE model using DiffSL's ``N`` and
-``stop`` constructs, matching the dosing-schedule pattern
-described in the `DiffSL hybrid ODE documentation <https://martinjrobins.github.io/diffsl/odes.html>`_.
+``stop`` constructs, see the `DiffSL hybrid ODE documentation <https://martinjrobins.github.io/diffsl/odes.html>`_.
 
-Protocol events are expanded to an explicit list of one-off boundary transitions:
-
-* A ``pace_i`` vector holds the pace level for each model phase indexed by ``N``.
-* A ``stop_i`` vector encodes each transition time; stop element ``k`` crosses
-  zero at time ``t_{k+1}``, triggering a solver stop and setting ``N = k``.
-State variables are preserved by default at transitions; pace changes are
-communicated through the updated ``N``\→``pace_i[N]`` lookup.
-
-If a protocol is provided, a ``final_time`` must be passed to
-:meth:`DiffSLExporter.model` so expansion is always finite.
+Periodic protocol events are expanded to an explicit list of one-off dose transitions. If a protocol is provided, a ``final_time`` must be passed to
+:meth:`DiffSLExporter.model` so this expansion is always finite.
 
 Exporters and expression writers
 ================================

--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -19,12 +19,6 @@ class DiffSLExporter(myokit.formats.Exporter):
     This :class:`Exporter <myokit.formats.Exporter>` generates a DiffSL
     implementation of a Myokit model.
 
-    When a :class:`myokit.Protocol` is supplied the exporter generates a
-    hybrid ODE model using DiffSL's ``N``/``stop``/``reset`` constructs.  All
-    protocol events (including periodic ones) are flattened into a finite list
-    of one-off transitions, so ``final_time`` must be provided whenever a
-    protocol is used.
-
     For details of the DiffSL language, see
     https://martinjrobins.github.io/diffsl/
     """

--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -19,14 +19,18 @@ class DiffSLExporter(myokit.formats.Exporter):
     This :class:`Exporter <myokit.formats.Exporter>` generates a DiffSL
     implementation of a Myokit model.
 
-    Only the model definition is exported. No inputs are provided, there is
-    no protocol defined, and only state variables are output.
+    When a :class:`myokit.Protocol` is supplied the exporter generates a
+    hybrid ODE model using DiffSL's ``N``/``stop``/``reset`` constructs.  All
+    protocol events (including periodic ones) are flattened into a finite list
+    of one-off transitions, so ``final_time`` must be provided whenever a
+    protocol is used.
 
-    For details of the language, see https://martinjrobins.github.io/diffsl/
+    For details of the DiffSL language, see
+    https://martinjrobins.github.io/diffsl/
     """
 
     def model(self, path, model, protocol=None, convert_units=True,
-              inputs=None, outputs=None):
+              inputs=None, outputs=None, final_time=None):
         """
         Exports a :class:`myokit.Model` in DiffSL format, writing the result to
         the file indicated by ``path``.
@@ -44,7 +48,11 @@ class DiffSLExporter(myokit.formats.Exporter):
         ``model``
             The :class:`myokit.Model` to export.
         ``protocol``
-            Not implemented!
+            An optional :class:`myokit.Protocol` that defines a pacing or
+            dosing schedule.  When given, the exporter generates a hybrid ODE
+            model using DiffSL's ``N``, ``stop``, and ``reset`` constructs.
+            All events are expanded to one-off transitions; periodic events
+            require ``final_time`` to be set.
         ``convert_units``
             If set to ``True`` (default), the method will attempt to convert to
             preferred units for voltage (mV), current (A/F), and time (ms).
@@ -57,12 +65,26 @@ class DiffSLExporter(myokit.formats.Exporter):
             (out_i { ... }). If ``None`` (default), all state variables will
             be included in alphabetical order. All output variables must be
             time-varying (not constants).
+        ``final_time``
+            Required when ``protocol`` is provided. Events are expanded up to
+            (but not including) this time. Must be a finite positive number.
+            Ignored when ``protocol`` is ``None``.
         """
-        # Raise exception if protocol is set
+        # Validate protocol / final_time combination
         if protocol is not None:
-            raise ValueError(
-                'DiffSL export does not support an input protocol.'
-            )
+            import math
+            if final_time is None:
+                raise myokit.ExportError(
+                    'A final_time must be provided when exporting with a '
+                    'protocol so events can be expanded to a finite list of '
+                    'transitions.'
+                )
+            if final_time is not None:
+                final_time = float(final_time)
+                if not math.isfinite(final_time) or final_time <= 0:
+                    raise myokit.ExportError(
+                        'final_time must be a finite positive number.'
+                    )
 
         # Check model validity
         try:
@@ -136,12 +158,58 @@ class DiffSLExporter(myokit.formats.Exporter):
         else:
             outputs = [model.get(qname) for qname in output_qnames]
 
+        # Expand protocol to hybrid phase boundaries (if supplied)
+        phases = None
+        if protocol is not None:
+            phases = self._expand_protocol(protocol, final_time)
+
         # Generate DiffSL model
-        diffsl_model = self._generate_diffsl(model, inputs, outputs)
+        diffsl_model = self._generate_diffsl(model, inputs, outputs, phases)
 
         # Write DiffSL model to file
         with open(path, 'w') as f:
             f.write(diffsl_model)
+
+    def _expand_protocol(self, protocol, final_time):
+        """
+        Expand a :class:`myokit.Protocol` directly into hybrid phase
+        boundaries ``(t_boundary, level_after)``.
+
+        Expansion is performed by stepping a :class:`myokit.PacingSystem`
+        through its event boundaries until the expansion horizon is reached.
+
+        Returns a list of ``(t_boundary, level_after)`` tuples in ascending
+        order of ``t_boundary``.
+
+        If pacing is already non-zero at ``t = 0``, a boundary ``(0.0, level)``
+        is included. If pacing remains non-zero at ``final_time``, a terminal
+        boundary ``(final_time, 0.0)`` is appended.
+        """
+        horizon = float(final_time)
+
+        pacing = myokit.PacingSystem(protocol)
+        current_level = pacing.pace()
+        phases = []
+
+        # Immediate transition at t=0 if pace starts non-zero.
+        if current_level != 0:
+            phases.append((0.0, current_level))
+
+        # Step through all pacing boundaries up to the horizon.
+        while True:
+            t_next = pacing.next_time()
+            if t_next >= horizon:
+                break
+            old_level = current_level
+            current_level = pacing.advance(t_next)
+            if current_level != old_level:
+                phases.append((t_next, current_level))
+
+        # Ensure return to baseline at final_time if pace remains active.
+        if current_level != 0:
+            phases.append((horizon, 0.0))
+
+        return phases
 
     def _prep_model(self, model, convert_units):
         """
@@ -213,7 +281,7 @@ class DiffSLExporter(myokit.formats.Exporter):
             'Not a variable or LhsExpression: ' + str(e)
         )
 
-    def _generate_diffsl(self, model, inputs, outputs):
+    def _generate_diffsl(self, model, inputs, outputs, phases=None):
         """
         Generate a DiffSL model from a prepped Myokit model.
 
@@ -225,6 +293,11 @@ class DiffSLExporter(myokit.formats.Exporter):
             List of model variables to include in the input parameter list.
         ``outputs``
             List of model variables to include in the output list.
+        ``phases``
+            Optional list of ``(t_boundary, level_after)`` tuples produced by
+            :meth:`_expand_protocol`. When provided, hybrid
+            ``pace_i``/``stop`` blocks are appended and the model
+            is expected to reference ``pace_i[N]`` for the current pace level.
         """
 
         # Create an expression writer
@@ -366,6 +439,41 @@ class DiffSLExporter(myokit.formats.Exporter):
             export_lines.append(f'{tab}{lhs},')
         export_lines.append('}')
         export_lines.append('')
+
+        # --- Hybrid protocol blocks (emitted when a protocol is supplied) ---
+        if phases is not None:
+            # phases: [(t_boundary, level_after), ...] sorted by t_boundary.
+            #
+            # DiffSL hybrid convention used here:
+            #   N = 0           before the first boundary
+            #   N = k (k >= 1) after boundary index k-1 fires
+            #
+            # pace_i[N] gives the pace level active in phase N.
+            # Phase 0 starts at t=0 (pace = 0, before any event).
+            # Phase k (k >= 1) is entered when stop element k-1 crosses zero.
+
+            # Collect pace levels: phase 0 is baseline (0.0), then one per
+            # boundary transition.
+            pace_levels = [0.0] + [lev for _, lev in phases]
+
+            # Emit pace level vector indexed by N
+            export_lines.append('/* Protocol: pace level per model index N */')
+            export_lines.append('pace_i {')
+            for lev in pace_levels:
+                export_lines.append(f'{tab}{lev},')
+            export_lines.append('}')
+            export_lines.append('')
+
+            # Emit stop conditions: stop[k] = t - t_{k+1}
+            # When element k crosses zero the solver stops and N is set to k.
+            export_lines.append(
+                '/* Protocol: stop conditions (stop[k] = t - t_{k+1}) */'
+            )
+            export_lines.append('stop_i {')
+            for t_boundary, _ in phases:
+                export_lines.append(f'{tab}t - {t_boundary},')
+            export_lines.append('}')
+            export_lines.append('')
 
         return '\n'.join(export_lines)
 

--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -6,6 +6,7 @@
 #
 import collections
 import warnings
+import math
 
 import myokit
 import myokit.formats
@@ -66,14 +67,13 @@ class DiffSLExporter(myokit.formats.Exporter):
         """
         # Validate protocol / final_time combination
         if protocol is not None:
-            import math
             if final_time is None:
                 raise myokit.ExportError(
                     'A final_time must be provided when exporting with a '
                     'protocol so events can be expanded to a finite list of '
                     'transitions.'
                 )
-            if final_time is not None:
+            else:
                 final_time = float(final_time)
                 if not math.isfinite(final_time) or final_time <= 0:
                     raise myokit.ExportError(
@@ -434,7 +434,7 @@ class DiffSLExporter(myokit.formats.Exporter):
         export_lines.append('}')
         export_lines.append('')
 
-        # --- Hybrid protocol blocks (emitted when a protocol is supplied) ---
+        # Hybrid protocol blocks (emitted when a protocol is supplied)
         if phases is not None:
             # phases: [(t_boundary, level_after), ...] sorted by t_boundary.
             #

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -150,6 +150,9 @@ out_i {
 class DiffSLExporterTest(unittest.TestCase):
     """Tests DiffSL export."""
 
+class DiffSLExporterTest(unittest.TestCase):
+    """Tests DiffSL export."""
+
     def test_diffsl_exporter(self):
         # Tests exporting a model
 
@@ -161,10 +164,6 @@ class DiffSLExporterTest(unittest.TestCase):
 
             # Test with simple model
             e.model(path, model)
-
-            # Test with protocol set
-            with self.assertRaisesRegex(ValueError, 'input protocol'):
-                e.model(path, model, protocol='-80 + 120*heaviside(t-10)')
 
             # Test with extra bound variables
             model.get('membrane.C').set_binding('hello')
@@ -180,6 +179,238 @@ class DiffSLExporterTest(unittest.TestCase):
             v.set_rhs('2 * V')
             with self.assertRaisesRegex(myokit.ExportError, 'valid model'):
                 e.model(path, model)
+
+    def test_protocol_one_off_events(self):
+        # Tests exporting a model with one-off (non-periodic) protocol events.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        p = myokit.Protocol()
+        p.schedule(level=1, start=100, duration=5)   # single dose at t=100
+        p.schedule(level=1, start=200, duration=5)   # single dose at t=200
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+            e.model(path, model, protocol=p, final_time=300)
+
+            with open(path, 'r') as f:
+                content = f.read()
+
+        # Hybrid blocks must be present
+        self.assertIn('pace_i', content)
+        self.assertIn('stop_i', content)
+
+        # pace_i has one extra phase compared to transitions:
+        # phases = [t=100 up, t=105 down, t=200 up, t=205 down] -> 4 boundaries
+        # pace_i entries: phase-0 baseline + 4 transitions = 5 entries
+        pace_match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
+        self.assertIsNotNone(pace_match)
+        pace_entries = [
+            ln.strip().rstrip(',')
+            for ln in pace_match.group(1).strip().splitlines()
+            if ln.strip()
+        ]
+        self.assertEqual(len(pace_entries), 5)
+
+        # stop_i must contain 4 boundary conditions
+        stop_match = re.search(r'stop_i\s*\{([^}]*)\}', content, re.DOTALL)
+        self.assertIsNotNone(stop_match)
+        stop_entries = [
+            ln.strip()
+            for ln in stop_match.group(1).strip().splitlines()
+            if ln.strip()
+        ]
+        self.assertEqual(len(stop_entries), 4)
+
+        # The boundary times for a level-1 event [100, 105) and [200, 205):
+        self.assertIn('t - 100.0', content)
+        self.assertIn('t - 105.0', content)
+        self.assertIn('t - 200.0', content)
+        self.assertIn('t - 205.0', content)
+
+
+    def test_protocol_periodic_requires_final_time(self):
+        # Tests that any protocol without final_time raises ExportError.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        p = myokit.Protocol()
+        p.schedule(level=1, start=0, duration=5, period=100)  # indefinite
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+            with self.assertRaisesRegex(
+                myokit.ExportError, 'final_time'
+            ):
+                e.model(path, model, protocol=p)
+
+        # Also true for non-periodic protocols
+        p2 = myokit.Protocol()
+        p2.schedule(level=1, start=10, duration=5)
+        with TemporaryDirectory() as d:
+            path = d.path('protocol2.diffsl')
+            with self.assertRaisesRegex(
+                myokit.ExportError, 'final_time'
+            ):
+                e.model(path, model, protocol=p2)
+
+    def test_protocol_periodic_with_final_time(self):
+        # Tests that a periodic protocol is correctly expanded to final_time.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        # Indefinite: period=100, duration=5, start=0
+        p = myokit.Protocol()
+        p.schedule(level=1, start=0, duration=5, period=100)
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+            e.model(path, model, protocol=p, final_time=250)
+
+            with open(path, 'r') as f:
+                content = f.read()
+
+        # Occurrences within [0, 250): starts at 0, 100, 200 -> 3 occurrences
+        # Each occurrence has a rising and falling edge -> 6 boundaries total
+        # pace_i: 1 (baseline) + 6 boundaries = 7 entries
+        pace_match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
+        self.assertIsNotNone(pace_match)
+        pace_entries = [
+            ln.strip()
+            for ln in pace_match.group(1).strip().splitlines()
+            if ln.strip()
+        ]
+        self.assertEqual(len(pace_entries), 7)
+
+        # stop_i must list 6 boundary times
+        stop_match = re.search(r'stop_i\s*\{([^}]*)\}', content, re.DOTALL)
+        self.assertIsNotNone(stop_match)
+        stop_entries = [
+            ln.strip()
+            for ln in stop_match.group(1).strip().splitlines()
+            if ln.strip()
+        ]
+        self.assertEqual(len(stop_entries), 6)
+
+    def test_protocol_finite_periodic(self):
+        # Tests that a finitely recurring periodic event is expanded correctly.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        # Fires exactly 2 times: at t=10 and t=110
+        p = myokit.Protocol()
+        p.schedule(level=1, start=10, duration=5, period=100, multiplier=2)
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+            e.model(path, model, protocol=p, final_time=500)
+
+            with open(path, 'r') as f:
+                content = f.read()
+
+        # 2 occurrences × 2 edges = 4 boundaries; pace_i = 5 entries
+        pace_match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
+        self.assertIsNotNone(pace_match)
+        pace_entries = [
+            ln.strip()
+            for ln in pace_match.group(1).strip().splitlines()
+            if ln.strip()
+        ]
+        self.assertEqual(len(pace_entries), 5)
+
+        self.assertIn('t - 10.0', content)
+        self.assertIn('t - 15.0', content)
+        self.assertIn('t - 110.0', content)
+        self.assertIn('t - 115.0', content)
+
+    def test_protocol_invalid_final_time(self):
+        # Tests that invalid final_time values raise ExportError.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        p = myokit.Protocol()
+        p.schedule(level=1, start=0, duration=5, period=100)
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+
+            with self.assertRaisesRegex(myokit.ExportError, 'final_time'):
+                e.model(path, model, protocol=p, final_time=-1)
+
+            with self.assertRaisesRegex(myokit.ExportError, 'final_time'):
+                e.model(path, model, protocol=p, final_time=0)
+
+            import math
+            with self.assertRaisesRegex(myokit.ExportError, 'final_time'):
+                e.model(path, model, protocol=p, final_time=math.inf)
+
+    def test_protocol_empty_after_expansion(self):
+        # Tests export when protocol has no non-zero events before final_time.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        # Event starts at t=500, final_time=100 -> no occurrences
+        p = myokit.Protocol()
+        p.schedule(level=1, start=500, duration=5, period=100)
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+            e.model(path, model, protocol=p, final_time=100)
+
+            with open(path, 'r') as f:
+                content = f.read()
+
+        # Only baseline phase is present (pace=0 throughout [0, 100)).
+        self.assertIn('pace_i', content)
+        self.assertIn('stop_i', content)
+        match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
+        self.assertIsNotNone(match)
+        entries = [
+            ln.strip().rstrip(',')
+            for ln in match.group(1).strip().splitlines()
+            if ln.strip()
+        ]
+        self.assertEqual(entries, ['0.0'])
+
+    def test_protocol_mixed_events(self):
+        # Tests a mixed protocol: one-off + periodic events together.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        p = myokit.Protocol()
+        # One-off loading dose at t=0
+        p.schedule(level=2, start=0, duration=1)
+        # Periodic maintenance dose, start=24, period=24, indefinite
+        p.schedule(level=1, start=24, duration=1, period=24)
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+            e.model(path, model, protocol=p, final_time=72)
+
+            with open(path, 'r') as f:
+                content = f.read()
+
+        # Hybrid blocks must be present
+        self.assertIn('pace_i', content)
+        self.assertIn('stop_i', content)
+
+        # One-off [0, 1) + periodic [24, 25), [48, 49) within final_time=72
+        # 3 occurrences × 2 edges = 6 boundaries; pace_i = 7 entries
+        pace_match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
+        self.assertIsNotNone(pace_match)
+        pace_entries = [
+            ln.strip()
+            for ln in pace_match.group(1).strip().splitlines()
+            if ln.strip()
+        ]
+        self.assertEqual(len(pace_entries), 7)
 
     def test_explicit_time_dependence(self):
         # Tests that explicit time dependence (dot(y) = -y * t) is supported

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -8,6 +8,7 @@
 import itertools
 import re
 import unittest
+import math
 
 import myokit
 import myokit.formats
@@ -324,7 +325,6 @@ class DiffSLExporterTest(unittest.TestCase):
             with self.assertRaisesRegex(myokit.ExportError, 'final_time'):
                 e.model(path, model, protocol=p, final_time=0)
 
-            import math
             with self.assertRaisesRegex(myokit.ExportError, 'final_time'):
                 e.model(path, model, protocol=p, final_time=math.inf)
 

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -147,6 +147,19 @@ out_i {
 """
 
 
+def _extract_block_entries(testcase, content, block_name):
+    """Extract entries from a DiffSL block like ``pace_i { ... }``."""
+    pattern = r'%s\s*\{([^}]*)\}' % re.escape(block_name)
+    match = re.search(pattern, content, re.DOTALL)
+    testcase.assertIsNotNone(match)
+    entries = [
+        ln.strip().rstrip(',')
+        for ln in match.group(1).strip().splitlines()
+        if ln.strip()
+    ]
+    return entries
+
+
 class DiffSLExporterTest(unittest.TestCase):
     """Tests DiffSL export."""
 
@@ -204,23 +217,11 @@ class DiffSLExporterTest(unittest.TestCase):
         # pace_i has one extra phase compared to transitions:
         # phases = [t=100 up, t=105 down, t=200 up, t=205 down] -> 4 boundaries
         # pace_i entries: phase-0 baseline + 4 transitions = 5 entries
-        pace_match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
-        self.assertIsNotNone(pace_match)
-        pace_entries = [
-            ln.strip().rstrip(',')
-            for ln in pace_match.group(1).strip().splitlines()
-            if ln.strip()
-        ]
+        pace_entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(len(pace_entries), 5)
 
         # stop_i must contain 4 boundary conditions
-        stop_match = re.search(r'stop_i\s*\{([^}]*)\}', content, re.DOTALL)
-        self.assertIsNotNone(stop_match)
-        stop_entries = [
-            ln.strip()
-            for ln in stop_match.group(1).strip().splitlines()
-            if ln.strip()
-        ]
+        stop_entries = _extract_block_entries(self, content, 'stop_i')
         self.assertEqual(len(stop_entries), 4)
 
         # The boundary times for a level-1 event [100, 105) and [200, 205):
@@ -276,23 +277,11 @@ class DiffSLExporterTest(unittest.TestCase):
         # Occurrences within [0, 250): starts at 0, 100, 200 -> 3 occurrences
         # Each occurrence has a rising and falling edge -> 6 boundaries total
         # pace_i: 1 (baseline) + 6 boundaries = 7 entries
-        pace_match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
-        self.assertIsNotNone(pace_match)
-        pace_entries = [
-            ln.strip()
-            for ln in pace_match.group(1).strip().splitlines()
-            if ln.strip()
-        ]
+        pace_entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(len(pace_entries), 7)
 
         # stop_i must list 6 boundary times
-        stop_match = re.search(r'stop_i\s*\{([^}]*)\}', content, re.DOTALL)
-        self.assertIsNotNone(stop_match)
-        stop_entries = [
-            ln.strip()
-            for ln in stop_match.group(1).strip().splitlines()
-            if ln.strip()
-        ]
+        stop_entries = _extract_block_entries(self, content, 'stop_i')
         self.assertEqual(len(stop_entries), 6)
 
     def test_protocol_finite_periodic(self):
@@ -313,13 +302,7 @@ class DiffSLExporterTest(unittest.TestCase):
                 content = f.read()
 
         # 2 occurrences × 2 edges = 4 boundaries; pace_i = 5 entries
-        pace_match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
-        self.assertIsNotNone(pace_match)
-        pace_entries = [
-            ln.strip()
-            for ln in pace_match.group(1).strip().splitlines()
-            if ln.strip()
-        ]
+        pace_entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(len(pace_entries), 5)
 
         self.assertIn('t - 10.0', content)
@@ -369,13 +352,7 @@ class DiffSLExporterTest(unittest.TestCase):
         # Only baseline phase is present (pace=0 throughout [0, 100)).
         self.assertIn('pace_i', content)
         self.assertIn('stop_i', content)
-        match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
-        self.assertIsNotNone(match)
-        entries = [
-            ln.strip().rstrip(',')
-            for ln in match.group(1).strip().splitlines()
-            if ln.strip()
-        ]
+        entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(entries, ['0.0'])
 
     def test_protocol_mixed_events(self):
@@ -403,13 +380,7 @@ class DiffSLExporterTest(unittest.TestCase):
 
         # One-off [0, 1) + periodic [24, 25), [48, 49) within final_time=72
         # 3 occurrences × 2 edges = 6 boundaries; pace_i = 7 entries
-        pace_match = re.search(r'pace_i\s*\{([^}]*)\}', content, re.DOTALL)
-        self.assertIsNotNone(pace_match)
-        pace_entries = [
-            ln.strip()
-            for ln in pace_match.group(1).strip().splitlines()
-            if ln.strip()
-        ]
+        pace_entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(len(pace_entries), 7)
 
     def test_explicit_time_dependence(self):

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -351,6 +351,31 @@ class DiffSLExporterTest(unittest.TestCase):
         entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(entries, ['0.0'])
 
+    def test_protocol_active_at_final_time(self):
+        # Tests that a terminal boundary is added when pacing is still active
+        # at final_time.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        # Event is active on [90, 110), so it is still on at final_time=100.
+        p = myokit.Protocol()
+        p.schedule(level=1, start=90, duration=20)
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+            e.model(path, model, protocol=p, final_time=100)
+
+            with open(path, 'r') as f:
+                content = f.read()
+
+        # Boundaries should be: t=90 goes to level 1, t=100 returns to 0.
+        pace_entries = _extract_block_entries(self, content, 'pace_i')
+        stop_entries = _extract_block_entries(self, content, 'stop_i')
+
+        self.assertEqual(pace_entries, ['0.0', '1.0', '0.0'])
+        self.assertEqual(stop_entries, ['t - 90.0', 't - 100.0'])
+
     def test_protocol_mixed_events(self):
         # Tests a mixed protocol: one-off + periodic events together.
 

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -163,9 +163,6 @@ def _extract_block_entries(testcase, content, block_name):
 class DiffSLExporterTest(unittest.TestCase):
     """Tests DiffSL export."""
 
-class DiffSLExporterTest(unittest.TestCase):
-    """Tests DiffSL export."""
-
     def test_diffsl_exporter(self):
         # Tests exporting a model
 
@@ -229,7 +226,6 @@ class DiffSLExporterTest(unittest.TestCase):
         self.assertIn('t - 105.0', content)
         self.assertIn('t - 200.0', content)
         self.assertIn('t - 205.0', content)
-
 
     def test_protocol_periodic_requires_final_time(self):
         # Tests that any protocol without final_time raises ExportError.


### PR DESCRIPTION
allow passing protocols into the diffsl exporter. These are implemented in diffsl as a hybrid model (https://martinjrobins.github.io/diffsl/odes.html)