### PR TITLE
feat(diffsl): multiple protocols

### DIFF
--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -43,11 +43,13 @@ class DiffSLExporter(myokit.formats.Exporter):
         ``model``
             The :class:`myokit.Model` to export.
         ``protocol``
-            An optional :class:`myokit.Protocol` that defines a pacing or
-            dosing schedule.  When given, the exporter generates a hybrid ODE
-            model using DiffSL's ``N``, ``stop``, and ``reset`` constructs.
-            All events are expanded to one-off transitions; periodic events
-            require ``final_time`` to be set.
+            An optional :class:`myokit.Protocol` or sequence of
+            protocols that defines a pacing or dosing schedule. When given,
+            the exporter generates a hybrid ODE model using DiffSL's ``N``,
+            ``stop``, and ``reset`` constructs. A single protocol is expanded
+            into one-off transitions; multiple protocols are solved
+            sequentially for one window of ``final_time`` each, resetting the
+            state to the model's initial condition between windows.
         ``convert_units``
             If set to ``True`` (default), the method will attempt to convert to
             preferred units for voltage (mV), current (A/F), and time (ms).
@@ -61,12 +63,16 @@ class DiffSLExporter(myokit.formats.Exporter):
             be included in alphabetical order. All output variables must be
             time-varying (not constants).
         ``final_time``
-            Required when ``protocol`` is provided. Events are expanded up to
-            (but not including) this time. Must be a finite positive number.
-            Ignored when ``protocol`` is ``None``.
+            Required when ``protocol`` is provided. For a single protocol,
+            events are expanded up to (but not including) this time. For a
+            sequence of protocols, each protocol is expanded over
+            ``[0, final_time)`` before being offset into its own window. Must
+            be a finite positive number. Ignored when ``protocol`` is
+            ``None``.
         """
         # Validate protocol / final_time combination
-        if protocol is not None:
+        protocols = self._normalize_protocols(protocol)
+        if protocols is not None:
             if final_time is None:
                 raise myokit.ExportError(
                     'A final_time must be provided when exporting with a '
@@ -95,6 +101,11 @@ class DiffSLExporter(myokit.formats.Exporter):
         else:
             input_qnames = []
             for v in inputs:
+                if protocols is not None and v.binding() == 'pace':
+                    raise myokit.ExportError(
+                        'The pace input cannot be provided explicitly when '
+                        'exporting with protocol-driven hybrid DiffSL output.'
+                    )
                 # Validate that the variable belongs to this model
                 if v.model() != model:
                     raise myokit.ExportError(
@@ -154,8 +165,8 @@ class DiffSLExporter(myokit.formats.Exporter):
 
         # Expand protocol to hybrid phase boundaries (if supplied)
         phases = None
-        if protocol is not None:
-            phases = self._expand_protocol(protocol, final_time)
+        if protocols is not None:
+            phases = self._create_hybrid_schedule(protocols, final_time)
 
         # Generate DiffSL model
         diffsl_model = self._generate_diffsl(model, inputs, outputs, phases)
@@ -164,30 +175,52 @@ class DiffSLExporter(myokit.formats.Exporter):
         with open(path, 'w') as f:
             f.write(diffsl_model)
 
+    def _normalize_protocols(self, protocol):
+        """
+        Normalize a protocol argument to ``None`` or a non-empty list of
+        :class:`myokit.Protocol` objects.
+        """
+        if protocol is None:
+            return None
+
+        if isinstance(protocol, myokit.Protocol):
+            return [protocol]
+
+        if not isinstance(protocol, collections.abc.Sequence):
+            raise myokit.ExportError(
+                'protocol must be None, a myokit.Protocol, or a non-empty '
+                'sequence of myokit.Protocol objects.'
+            )
+
+        protocols = list(protocol)
+        if not protocols:
+            return None
+
+        for item in protocols:
+            if not isinstance(item, myokit.Protocol):
+                raise myokit.ExportError(
+                    'Each item in protocol must be a myokit.Protocol.'
+                )
+        return protocols
+
     def _expand_protocol(self, protocol, final_time):
         """
-        Expand a :class:`myokit.Protocol` directly into hybrid phase
+        Expand a :class:`myokit.Protocol` directly into protocol-local phase
         boundaries ``(t_boundary, level_after)``.
 
         Expansion is performed by stepping a :class:`myokit.PacingSystem`
         through its event boundaries until the expansion horizon is reached.
 
         Returns a list of ``(t_boundary, level_after)`` tuples in ascending
-        order of ``t_boundary``.
-
-        If pacing is already non-zero at ``t = 0``, a boundary ``(0.0, level)``
-        is included. If pacing remains non-zero at ``final_time``, a terminal
-        boundary ``(final_time, 0.0)`` is appended.
+        order of ``t_boundary``. The first entry is always ``(0.0,
+        initial_level)`` where ``initial_level`` is the pacing level at
+        ``t = 0``.
         """
         horizon = float(final_time)
 
         pacing = myokit.PacingSystem(protocol)
-        current_level = pacing.pace()
-        phases = []
-
-        # Immediate transition at t=0 if pace starts non-zero.
-        if current_level != 0:
-            phases.append((0.0, current_level))
+        initial_level = current_level = float(pacing.pace())
+        phases = [(0.0, initial_level)]
 
         # Step through all pacing boundaries up to the horizon.
         while True:
@@ -195,13 +228,37 @@ class DiffSLExporter(myokit.formats.Exporter):
             if t_next >= horizon:
                 break
             old_level = current_level
-            current_level = pacing.advance(t_next)
+            current_level = float(pacing.advance(t_next))
             if current_level != old_level:
                 phases.append((t_next, current_level))
 
-        # Ensure return to baseline at final_time if pace remains active.
-        if current_level != 0:
-            phases.append((horizon, 0.0))
+        return phases
+
+    def _create_hybrid_schedule(self, protocols, final_time):
+        """
+        Create a global hybrid phase schedule for one or more protocols.
+
+        Returns a list of ``(start_time, pace_level, reset_to_initial)``
+        tuples ordered by phase index.
+        """
+        expanded = [
+            self._expand_protocol(protocol, final_time)
+            for protocol in protocols
+        ]
+        phases = [(0.0, expanded[0][0][1], False)]
+
+        for i, boundaries in enumerate(expanded):
+            offset = i * final_time
+
+            for t_boundary, level_after in boundaries[1:]:
+                phases.append((offset + t_boundary, level_after, False))
+
+            if i + 1 < len(expanded):
+                phases.append((offset + final_time, expanded[i + 1][0][1], True))
+
+        terminal_time = len(protocols) * final_time
+        if len(protocols) > 1 or phases[-1][1] != 0:
+            phases.append((terminal_time, 0.0, False))
 
         return phases
 
@@ -288,10 +345,10 @@ class DiffSLExporter(myokit.formats.Exporter):
         ``outputs``
             List of model variables to include in the output list.
         ``phases``
-            Optional list of ``(t_boundary, level_after)`` tuples produced by
-            :meth:`_expand_protocol`. When provided, hybrid
-            ``pace_i``/``stop`` blocks are appended and the model
-            is expected to reference ``pace_i[N]`` for the current pace level.
+            Optional list of ``(start_time, pace_level, reset_to_initial)``
+            tuples produced by :meth:`_create_hybrid_schedule`. When
+            provided, hybrid ``pace_i``/``stop_i``/``reset_i`` blocks are
+            appended and the bound pace variable is emitted as ``pace_i[N]``.
         """
 
         # Create an expression writer
@@ -354,7 +411,7 @@ class DiffSLExporter(myokit.formats.Exporter):
             export_lines.append('*/')
 
             lhs = self._var_name(pace)
-            rhs = e.ex(pace.rhs())
+            rhs = 'pace_i[N]' if phases is not None else e.ex(pace.rhs())
             qname = pace.qname()
             unit = '' if pace.unit() is None else f' {pace.unit()}'
             export_lines.append(f'{lhs} {{ {rhs} }} /* {qname}{unit} */')
@@ -393,6 +450,14 @@ class DiffSLExporter(myokit.formats.Exporter):
             export_lines.append(f'{tab}{lhs} = {rhs}, /* {qname}{unit} */')
         export_lines.append('}')
         export_lines.append('')
+
+        if phases is not None:
+            export_lines.append('/* Initial condition vector for resets */')
+            export_lines.append('u0_i {')
+            for v in model.states():
+                export_lines.append(f'{tab}{v.initial_value()},')
+            export_lines.append('}')
+            export_lines.append('')
 
         # Add remaining variables
         todo_vars = (
@@ -436,21 +501,19 @@ class DiffSLExporter(myokit.formats.Exporter):
 
         # Hybrid protocol blocks (emitted when a protocol is supplied)
         if phases is not None:
-            # phases: [(t_boundary, level_after), ...] sorted by t_boundary.
+            # phases: [(start_time, pace_level, reset_to_initial), ...]
+            # ordered by phase index.
             #
             # DiffSL hybrid convention used here:
-            #   N = 0           before the first boundary
-            #   N = k (k >= 1) after boundary index k-1 fires
+            #   N = 0           in the initial phase
+            #   N = k (k >= 1) after stop element k fires
             #
             # pace_i[N] gives the pace level active in phase N.
-            # Phase 0 starts at t=0 (pace = 0, before any event).
-            # Phase k (k >= 1) is entered when stop element k-1 crosses zero.
+            # Phase k is entered when stop element k crosses zero.
 
-            # Collect pace levels: phase 0 is baseline (0.0), then one per
-            # boundary transition.
-            pace_levels = [0.0] + [lev for _, lev in phases]
+            pace_levels = [lev for _, lev, _ in phases]
+            reset_flags = [1.0 if reset else 0.0 for _, _, reset in phases]
 
-            # Emit pace level vector indexed by N
             export_lines.append('/* Protocol: pace level per model index N */')
             export_lines.append('pace_i {')
             for lev in pace_levels:
@@ -458,15 +521,32 @@ class DiffSLExporter(myokit.formats.Exporter):
             export_lines.append('}')
             export_lines.append('')
 
-            # Emit stop conditions: stop[k] = t - t_{k+1}
-            # When element k crosses zero the solver stops and N is set to k.
             export_lines.append(
-                '/* Protocol: stop conditions (stop[k] = t - t_{k+1}) */'
+                '/* Protocol: reset mode per phase (1 = reset to u0_i) */'
+            )
+            export_lines.append('resetFlag_i {')
+            for flag in reset_flags:
+                export_lines.append(f'{tab}{flag},')
+            export_lines.append('}')
+            export_lines.append('')
+
+            export_lines.append(
+                '/* Protocol: stop conditions (stop[k] enters phase k) */'
             )
             export_lines.append('stop_i {')
-            for t_boundary, _ in phases:
+            export_lines.append(f'{tab}1.0,')
+            for t_boundary, _, _ in phases[1:]:
                 export_lines.append(f'{tab}t - {t_boundary},')
             export_lines.append('}')
+            export_lines.append('')
+
+            export_lines.append(
+                '/* Protocol: reset state on window boundaries */'
+            )
+            export_lines.append(
+                'reset_i { resetFlag_i[N] * u0_i +'
+                ' (1.0 - resetFlag_i[N]) * u_i }'
+            )
             export_lines.append('')
 
         return '\n'.join(export_lines)

--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -259,7 +259,7 @@ class DiffSLExporter(myokit.formats.Exporter):
                 )
 
         terminal_time = len(protocols) * final_time
-        if len(protocols) > 1 or phases[-1][1] != 0:
+        if phases[-1][1] != 0:
             phases.append((terminal_time, 0.0, False))
 
         return phases

--- a/myokit/formats/diffsl/_exporter.py
+++ b/myokit/formats/diffsl/_exporter.py
@@ -254,7 +254,9 @@ class DiffSLExporter(myokit.formats.Exporter):
                 phases.append((offset + t_boundary, level_after, False))
 
             if i + 1 < len(expanded):
-                phases.append((offset + final_time, expanded[i + 1][0][1], True))
+                phases.append(
+                    (offset + final_time, expanded[i + 1][0][1], True)
+                )
 
         terminal_time = len(protocols) * final_time
         if len(protocols) > 1 or phases[-1][1] != 0:

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -293,7 +293,10 @@ class DiffSLExporterTest(unittest.TestCase):
         # Initial phase is active at t=0, then 5 more transitions follow.
         pace_entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(len(pace_entries), 6)
-        self.assertEqual(pace_entries, ['1.0', '0.0', '1.0', '0.0', '1.0', '0.0'])
+        self.assertEqual(
+            pace_entries,
+            ['1.0', '0.0', '1.0', '0.0', '1.0', '0.0']
+        )
 
         # stop_i includes the sentinel at index 0 plus 5 future transitions.
         stop_entries = _extract_block_entries(self, content, 'stop_i')
@@ -394,7 +397,10 @@ class DiffSLExporterTest(unittest.TestCase):
         self.assertIn('stop_i', content)
         entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(entries, ['0.0'])
-        self.assertEqual(_extract_block_entries(self, content, 'stop_i'), ['1.0'])
+        self.assertEqual(
+            _extract_block_entries(self, content, 'stop_i'),
+            ['1.0']
+        )
 
     def test_protocol_active_at_final_time(self):
         # Tests that a terminal boundary is added when pacing is still active

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -161,6 +161,14 @@ def _extract_block_entries(testcase, content, block_name):
     return entries
 
 
+def _extract_block_content(testcase, content, block_name):
+    """Extract raw content from a DiffSL block like ``reset_i { ... }``."""
+    pattern = r'%s\s*\{([^}]*)\}' % re.escape(block_name)
+    match = re.search(pattern, content, re.DOTALL)
+    testcase.assertIsNotNone(match)
+    return match.group(1)
+
+
 class DiffSLExporterTest(unittest.TestCase):
     """Tests DiffSL export."""
 
@@ -211,16 +219,18 @@ class DiffSLExporterTest(unittest.TestCase):
         # Hybrid blocks must be present
         self.assertIn('pace_i', content)
         self.assertIn('stop_i', content)
+        self.assertIn('reset_i', content)
+        self.assertIn('enginePace { pace_i[N] }', content)
 
-        # pace_i has one extra phase compared to transitions:
-        # phases = [t=100 up, t=105 down, t=200 up, t=205 down] -> 4 boundaries
-        # pace_i entries: phase-0 baseline + 4 transitions = 5 entries
+        # pace_i contains one level per phase, starting with the initial phase.
         pace_entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(len(pace_entries), 5)
+        self.assertEqual(pace_entries, ['0.0', '1.0', '0.0', '1.0', '0.0'])
 
-        # stop_i must contain 4 boundary conditions
+        # stop_i index 0 is a sentinel to keep the initial phase at N = 0.
         stop_entries = _extract_block_entries(self, content, 'stop_i')
-        self.assertEqual(len(stop_entries), 4)
+        self.assertEqual(len(stop_entries), 5)
+        self.assertEqual(stop_entries[0], '1.0')
 
         # The boundary times for a level-1 event [100, 105) and [200, 205):
         self.assertIn('t - 100.0', content)
@@ -254,6 +264,14 @@ class DiffSLExporterTest(unittest.TestCase):
             ):
                 e.model(path, model, protocol=p2)
 
+        # Also true for multiple protocols
+        with TemporaryDirectory() as d:
+            path = d.path('protocol3.diffsl')
+            with self.assertRaisesRegex(
+                myokit.ExportError, 'final_time'
+            ):
+                e.model(path, model, protocol=[p, p2])
+
     def test_protocol_periodic_with_final_time(self):
         # Tests that a periodic protocol is correctly expanded to final_time.
 
@@ -272,14 +290,15 @@ class DiffSLExporterTest(unittest.TestCase):
                 content = f.read()
 
         # Occurrences within [0, 250): starts at 0, 100, 200 -> 3 occurrences
-        # Each occurrence has a rising and falling edge -> 6 boundaries total
-        # pace_i: 1 (baseline) + 6 boundaries = 7 entries
+        # Initial phase is active at t=0, then 5 more transitions follow.
         pace_entries = _extract_block_entries(self, content, 'pace_i')
-        self.assertEqual(len(pace_entries), 7)
+        self.assertEqual(len(pace_entries), 6)
+        self.assertEqual(pace_entries, ['1.0', '0.0', '1.0', '0.0', '1.0', '0.0'])
 
-        # stop_i must list 6 boundary times
+        # stop_i includes the sentinel at index 0 plus 5 future transitions.
         stop_entries = _extract_block_entries(self, content, 'stop_i')
         self.assertEqual(len(stop_entries), 6)
+        self.assertEqual(stop_entries[0], '1.0')
 
     def test_protocol_finite_periodic(self):
         # Tests that a finitely recurring periodic event is expanded correctly.
@@ -298,7 +317,7 @@ class DiffSLExporterTest(unittest.TestCase):
             with open(path, 'r') as f:
                 content = f.read()
 
-        # 2 occurrences × 2 edges = 4 boundaries; pace_i = 5 entries
+        # 2 occurrences × 2 edges = 4 boundaries; initial phase + 4 transitions
         pace_entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(len(pace_entries), 5)
 
@@ -328,6 +347,31 @@ class DiffSLExporterTest(unittest.TestCase):
             with self.assertRaisesRegex(myokit.ExportError, 'final_time'):
                 e.model(path, model, protocol=p, final_time=math.inf)
 
+            with self.assertRaisesRegex(
+                myokit.ExportError, 'Each item in protocol'
+            ):
+                e.model(path, model, protocol=[p, object()], final_time=10)
+
+    def test_protocol_empty_sequence_matches_no_protocol(self):
+        # Tests that an empty protocol sequence is treated as no protocol.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        with TemporaryDirectory() as d:
+            path1 = d.path('no_protocol.diffsl')
+            path2 = d.path('empty_protocol_list.diffsl')
+
+            e.model(path1, model)
+            e.model(path2, model, protocol=[], final_time=10)
+
+            with open(path1, 'r') as f:
+                content1 = f.read()
+            with open(path2, 'r') as f:
+                content2 = f.read()
+
+        self.assertEqual(content1, content2)
+
     def test_protocol_empty_after_expansion(self):
         # Tests export when protocol has no non-zero events before final_time.
 
@@ -350,6 +394,7 @@ class DiffSLExporterTest(unittest.TestCase):
         self.assertIn('stop_i', content)
         entries = _extract_block_entries(self, content, 'pace_i')
         self.assertEqual(entries, ['0.0'])
+        self.assertEqual(_extract_block_entries(self, content, 'stop_i'), ['1.0'])
 
     def test_protocol_active_at_final_time(self):
         # Tests that a terminal boundary is added when pacing is still active
@@ -374,7 +419,7 @@ class DiffSLExporterTest(unittest.TestCase):
         stop_entries = _extract_block_entries(self, content, 'stop_i')
 
         self.assertEqual(pace_entries, ['0.0', '1.0', '0.0'])
-        self.assertEqual(stop_entries, ['t - 90.0', 't - 100.0'])
+        self.assertEqual(stop_entries, ['1.0', 't - 90.0', 't - 100.0'])
 
     def test_protocol_mixed_events(self):
         # Tests a mixed protocol: one-off + periodic events together.
@@ -398,11 +443,126 @@ class DiffSLExporterTest(unittest.TestCase):
         # Hybrid blocks must be present
         self.assertIn('pace_i', content)
         self.assertIn('stop_i', content)
+        self.assertIn('enginePace { pace_i[N] }', content)
 
         # One-off [0, 1) + periodic [24, 25), [48, 49) within final_time=72
-        # 3 occurrences × 2 edges = 6 boundaries; pace_i = 7 entries
+        # Initial phase is the loading dose, then 5 more transitions follow.
         pace_entries = _extract_block_entries(self, content, 'pace_i')
-        self.assertEqual(len(pace_entries), 7)
+        self.assertEqual(len(pace_entries), 6)
+
+    def test_protocol_list_with_single_protocol(self):
+        # Tests that protocol=[p] behaves like protocol=p.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        p = myokit.Protocol()
+        p.schedule(level=1, start=100, duration=5)
+
+        with TemporaryDirectory() as d:
+            path1 = d.path('protocol_single.diffsl')
+            path2 = d.path('protocol_list.diffsl')
+
+            e.model(path1, model, protocol=p, final_time=200)
+            e.model(path2, model, protocol=[p], final_time=200)
+
+            with open(path1, 'r') as f:
+                content1 = f.read()
+            with open(path2, 'r') as f:
+                content2 = f.read()
+
+        self.assertEqual(content1, content2)
+
+    def test_protocol_multiple_protocols(self):
+        # Tests that multiple protocols are sequenced across windows with
+        # reset-to-initial boundaries.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        p1 = myokit.Protocol()
+        p1.schedule(level=1, start=10, duration=5)
+
+        p2 = myokit.Protocol()
+        p2.schedule(level=2, start=0, duration=3)
+        p2.schedule(level=3, start=20, duration=4)
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocols.diffsl')
+            e.model(path, model, protocol=[p1, p2], final_time=50)
+
+            with open(path, 'r') as f:
+                content = f.read()
+
+        self.assertIn('enginePace { pace_i[N] }', content)
+
+        pace_entries = _extract_block_entries(self, content, 'pace_i')
+        stop_entries = _extract_block_entries(self, content, 'stop_i')
+        reset_flags = _extract_block_entries(self, content, 'resetFlag_i')
+
+        self.assertEqual(
+            pace_entries,
+            ['0.0', '1.0', '0.0', '2.0', '0.0', '3.0', '0.0', '0.0']
+        )
+        self.assertEqual(
+            stop_entries,
+            [
+                '1.0',
+                't - 10.0',
+                't - 15.0',
+                't - 50.0',
+                't - 53.0',
+                't - 70.0',
+                't - 74.0',
+                't - 100.0',
+            ]
+        )
+        self.assertEqual(
+            reset_flags,
+            ['0.0', '0.0', '0.0', '1.0', '0.0', '0.0', '0.0', '0.0']
+        )
+
+        u0_entries = _extract_block_entries(self, content, 'u0_i')
+        self.assertEqual(
+            u0_entries,
+            ['-84.5286', '0.0017', '0.9832', '0.995484', '3e-6', '1',
+             '0.0057', '0.0002']
+        )
+
+        reset_content = _extract_block_content(self, content, 'reset_i')
+        self.assertIn(
+            'resetFlag_i[N] * u0_i',
+            reset_content,
+        )
+        self.assertIn(
+            '(1.0 - resetFlag_i[N]) * u_i',
+            reset_content,
+        )
+
+    def test_protocol_multiple_protocols_rejects_pace_input(self):
+        # Tests that pace cannot be exported as an input when protocols drive
+        # the hybrid model.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        p1 = myokit.Protocol()
+        p1.schedule(level=1, start=10, duration=5)
+        p2 = myokit.Protocol()
+        p2.schedule(level=2, start=10, duration=5)
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocols.diffsl')
+            with self.assertRaisesRegex(
+                myokit.ExportError, 'pace input cannot be provided explicitly'
+            ):
+                e.model(
+                    path,
+                    model,
+                    protocol=[p1, p2],
+                    final_time=50,
+                    inputs=[model.get('engine.pace')],
+                )
 
     def test_explicit_time_dependence(self):
         # Tests that explicit time dependence (dot(y) = -y * t) is supported

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -355,6 +355,19 @@ class DiffSLExporterTest(unittest.TestCase):
             ):
                 e.model(path, model, protocol=[p, object()], final_time=10)
 
+    def test_protocol_invalid_type(self):
+        # Tests that non-sequence protocol values raise ExportError.
+
+        model = myokit.load_model('example')
+        e = myokit.formats.diffsl.DiffSLExporter()
+
+        with TemporaryDirectory() as d:
+            path = d.path('protocol.diffsl')
+            with self.assertRaisesRegex(
+                myokit.ExportError, 'protocol must be None'
+            ):
+                e.model(path, model, protocol=object(), final_time=10)
+
     def test_protocol_empty_sequence_matches_no_protocol(self):
         # Tests that an empty protocol sequence is treated as no protocol.
 

--- a/myokit/tests/test_formats_diffsl.py
+++ b/myokit/tests/test_formats_diffsl.py
@@ -521,7 +521,7 @@ class DiffSLExporterTest(unittest.TestCase):
 
         self.assertEqual(
             pace_entries,
-            ['0.0', '1.0', '0.0', '2.0', '0.0', '3.0', '0.0', '0.0']
+            ['0.0', '1.0', '0.0', '2.0', '0.0', '3.0', '0.0']
         )
         self.assertEqual(
             stop_entries,
@@ -533,12 +533,11 @@ class DiffSLExporterTest(unittest.TestCase):
                 't - 53.0',
                 't - 70.0',
                 't - 74.0',
-                't - 100.0',
             ]
         )
         self.assertEqual(
             reset_flags,
-            ['0.0', '0.0', '0.0', '1.0', '0.0', '0.0', '0.0', '0.0']
+            ['0.0', '0.0', '0.0', '1.0', '0.0', '0.0', '0.0']
         )
 
         u0_entries = _extract_block_entries(self, content, 'u0_i')


### PR DESCRIPTION
This is a draft atm, I just had a question @MichaelClerx:

I'm currently implementing multiple protocol support for the diffsl export, to match the functionality available in Simulation and cause I need it in pkpd explorer :) 

My question is, I am primarily interested in instantaneous dosing events with duration 0. After looking around myokit I don't think your pacing system support this, is that right?

Would you be ok if I put a new arg on the diffsl exporter, called something like "delta_pace_threshold", so that if "duration" is less than that threshold, the pacing is treated as a delta function. This translates into a single reset event in diffsl, whereas an finite time duration event is two separate reset events, so more efficient....

